### PR TITLE
Create an initial list of folks who should be in devrel-team@kubeflow.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # internal-acls
 
 Repository used to maintain group ACLs used by the Kubeflow community.
+
+The text files contain lists of folks that should be added
+to various Google Groups in kubeflow.org that control
+access to various shared resources.
+
+The script `sync_groups.sh` can be used to sync groups
+using the GAM CLI. Only administrators with appropriate
+permissions will be able to sync groups.

--- a/devrel-team.members.txt
+++ b/devrel-team.members.txt
@@ -1,0 +1,13 @@
+1sanyamkapoor@gmail.com
+agwl@google.com
+amyu@google.com
+chasm@google.com
+ewj@google.com
+github-team@kubeflow.org
+jlewi.dataflow@gmail.com
+jlewi@kubeflow.org
+kam.d.kasravi@intel.com
+kunming@google.com
+lunkai@google.com
+pmackinn@redhat.com
+wibuch@microsoft.com

--- a/sync_groups.sh
+++ b/sync_groups.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+# Sync groups using the gam CLI
+set -ex
+
+gam update group devrel-team@kubeflow.org sync member file devrel-team.members.txt


### PR DESCRIPTION
* This group is primarily used to grant access to kubeflow.org.
* I've only included current members of devrel-team@kubeflow.org who's
  email is already available in community/members.yaml. This means some
  users removed to avoid publicly sharing email addresses without consent.

* 1sanyamkapoor@gmail.com is the Google Kubeflow summer intern.