### PR TITLE
Create a new group to act as owners of kf-demo-owner.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,15 @@ access to various shared resources.
 The script `sync_groups.sh` can be used to sync groups
 using the GAM CLI. Only administrators with appropriate
 permissions will be able to sync groups.
+
+To create a new group
+
+```
+GROUP_NAME=google-kubecon-europe
+GROUP_EMAIL=${GROUP_NAME}@kubeflow.org 
+DESCRIPTION="Some group description"
+
+/home/jlewi/bin/gam/gam create group ${GROUP_EMAIL} who_can_join invited_can_join \
+  name ${GROUP_NAME} description "${DESCRIPTION}" \
+  allow_external_members true
+```

--- a/kf-demo-owners.members.txt
+++ b/kf-demo-owners.members.txt
@@ -1,0 +1,6 @@
+agwl@google.com
+aronchick@google.com
+chasm@google.com
+jlewi@google.com
+kunming@google.com
+lunkai@google.com

--- a/sync_groups.sh
+++ b/sync_groups.sh
@@ -3,4 +3,5 @@
 # Sync groups using the gam CLI
 set -ex
 
+gam update group kf-demo-owners@kubeflow.org sync member file kf-demo-owners.members.txt
 gam update group devrel-team@kubeflow.org sync member file devrel-team.members.txt


### PR DESCRIPTION
Create a new group to act as owners of project kf-demo-owner.

* It looks as if creating new projects via deployment manager might require individual users to be owners.

* @texasmichelle was trying and she was getting this error

```
gcloud --project=kf-demo-owner deployment-manager operations describe operation-1527544839653-56d4b3f8bc689-7b0d7d57-7cb99218
endTime: '2018-05-28T15:00:44.900-07:00'
error:
  errors:
  - code: RESOURCE_ERROR
    location: /deployments/kubeflow-demo/resources/kubeflow-demo
    message: '{"ResourceType":"cloudresourcemanager.v1.project","ResourceErrorCode":"403","ResourceErrorMessage":{"code":403,"message":"User
      is not authorized.","status":"PERMISSION_DENIED","statusMessage":"Forbidden","requestPath":"https://cloudresourcemanager.googleapis.com/v1/projects/kubeflow-demo","httpMethod":"GET"}}'
httpErrorMessage: BAD REQUEST
httpErrorStatusCode: 400
id: '6845374644462142184'
insertTime: '2018-05-28T15:00:39.816-07:00'
kind: deploymentmanager#operation
name: operation-1527544839653-56d4b3f8bc689-7b0d7d57-7cb99218
operationType: insert
progress: 100
selfLink: https://www.googleapis.com/deploymentmanager/v2/projects/kf-demo-owner/global/operations/operation-1527544839653-56d4b3f8bc689-7b0d7d57-7cb99218
startTime: '2018-05-28T15:00:40.154-07:00'
status: DONE
targetId: '4614639884427182824'
targetLink: https://www.googleapis.com/deploymentmanager/v2/projects/kf-demo-owner/global/deployments/kubeflow-demo
user: michellecasbon@google.com
```

Even though she had deployment manager permissions via the group google-kubecon-europe-members.txt.

/assign @texasmichelle 