### PR TITLE
add mrick to google-kubeflow team

### DIFF
--- a/google-kubeflow-admins.members.txt
+++ b/google-kubeflow-admins.members.txt
@@ -2,4 +2,5 @@ abhishek@google.com
 jlewi@google.com
 kunming@google.com
 lunkai@google.com
+mrick@google.com
 ricliu@google.com

--- a/google-team.members.txt
+++ b/google-team.members.txt
@@ -2,6 +2,7 @@ abhishek@google.com
 jlewi@google.com
 kunming@google.com
 lunkai@google.com
+mrick@google.com
 ricliu@google.com
 sanyamkapoor@google.com
 yxshi@google.com

--- a/release-team.members.txt
+++ b/release-team.members.txt
@@ -2,4 +2,5 @@ abhishek@google.com
 jlewi@google.com
 kunming@google.com
 lunkai@google.com
+mrick@google.com
 ricliu@google.com


### PR DESCRIPTION
Let me know if these are the right ACLs. I'd like to view the CI logs for failed jobs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/internal-acls/16)
<!-- Reviewable:end -->
