### PR TITLE
Checkin config for our GitHub org

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -42,16 +42,20 @@ orgs:
         - clemens-mewald
         - cliveseldon
         - codeflitting
+        - connordoyle
         - cwbeitel
         - danisla
+        - dakoner
         - ddutta
         - ddysher
         - DeeperMind
         - disktnk
         - DjangoPeng
         - dlaqab
+        - dmueller2001
         - dsdinter
         - dwhitena
+        - dynamicwebpaige
         - elsonrodriguez
         - erikerlandson
         - everpeace
@@ -67,6 +71,7 @@ orgs:
         - inc0
         - ioandr
         - IronPan
+        - jbottum
         - jiezhang
         - Jimexist
         - jinxingwang
@@ -76,6 +81,7 @@ orgs:
         - k8s-ci-robot
         - karthikv2k
         - katieole
+        - katsiapis
         - kiratp
         - kkasravi
         - krzyzacy
@@ -106,6 +112,7 @@ orgs:
         - r2d4
         - raddaoui
         - ramdootp
+        - randxie
         - rileyjbauer
         - rongou
         - ryanolson
@@ -127,6 +134,7 @@ orgs:
         - wbuchwalter
         - willb
         - willingc
+        - wjarek
         - xychu
         - xyhuang
         - yebrahim

--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -1,0 +1,318 @@
+orgs:
+    kubeflow:
+        admins:
+        - abhi-g
+        - google-admin
+        - googlebot
+        - jlewi
+        - richardsliu
+        - vicaire
+        billing_email: vishnukanan@gmail.com
+        company: ""
+        default_repository_permission: read
+        description: Kubeflow is an open, community driven project to make it easy to deploy
+          and manage an ML stack on Kubernetes
+        email: ""
+        has_organization_projects: true
+        has_repository_projects: true
+        location: ""
+        members:
+        - abkosar
+        - activatedgeek
+        - ahousley
+        - ajayalfred
+        - Akado2009
+        - alsrgv
+        - amsaha
+        - amygdala
+        - andreyvelich
+        - anfeng
+        - Ark-kun
+        - ashahba
+        - balajismaniam
+        - beberg
+        - BenTheElder
+        - bhupc
+        - carmark
+        - carmine
+        - ChanYiLin
+        - cheyang
+        - chrisheecho
+        - cjwagner
+        - clemens-mewald
+        - cliveseldon
+        - codeflitting
+        - cwbeitel
+        - danisla
+        - ddutta
+        - ddysher
+        - DeeperMind
+        - disktnk
+        - DjangoPeng
+        - dlaqab
+        - dsdinter
+        - dwhitena
+        - elsonrodriguez
+        - erikerlandson
+        - everpeace
+        - ewilderj
+        - frederick0329
+        - fxue
+        - gaocegege
+        - gaoning777
+        - garganubhav
+        - gsunner
+        - hongye-sun
+        - idvoretskyi
+        - inc0
+        - ioandr
+        - IronPan
+        - jiezhang
+        - Jimexist
+        - jinxingwang
+        - johnugeorge
+        - jose5918
+        - jzp1025
+        - k8s-ci-robot
+        - karthikv2k
+        - katieole
+        - kiratp
+        - kkasravi
+        - krzyzacy
+        - kubeflow-bot
+        - kunmingg
+        - ldcastell
+        - libbyandhelen
+        - lienhua34
+        - lluunn
+        - marcoceppi
+        - mattf
+        - Maximophone
+        - mhausenblas
+        - mitake
+        - moxyoron
+        - mpvartak
+        - netankit
+        - neuromage
+        - nickchase
+        - nqn
+        - ojarjur
+        - paveldournov
+        - pdmack
+        - pineking
+        - puneith
+        - pvellanki
+        - qimingj
+        - r2d4
+        - raddaoui
+        - ramdootp
+        - rileyjbauer
+        - rongou
+        - ryanolson
+        - salehay
+        - sambaiz
+        - sarahmaddox
+        - sasha-gitg
+        - sshrdp
+        - ScorpioCPH
+        - songole
+        - suleisl2000
+        - swiftdiaries
+        - texasmichelle
+        - TheJaySmith
+        - tmckayus
+        - vditya
+        - vishh
+        - vkoukis
+        - wbuchwalter
+        - willb
+        - willingc
+        - xychu
+        - xyhuang
+        - yebrahim
+        - yixinshi
+        - yncxcw
+        - yph152
+        - YujiOshima
+        - yupbank
+        - ziamsyed
+        - zjj2wry
+        members_can_create_repositories: false
+        name: Kubeflow
+        teams:
+          Caicloud:
+            description: Team of members from Caicloud
+            maintainers:
+            - ddysher
+            - gaocegege
+            members:
+            - lienhua34
+            - codeflitting
+            - zjj2wry
+            - yph152
+            privacy: closed
+          Cisco:
+            description: Team @Cisco contributing to KubeFlow
+            maintainers:
+            - ddutta
+            members:
+            - johnugeorge
+            - xyhuang
+            - Akado2009
+            - libbyandhelen
+            - garganubhav
+            - ramdootp
+            privacy: closed
+          Google:
+            description: Folks from Google working on Kubeflow
+            maintainers:
+            - jlewi
+            - abhi-g
+            - vicaire
+            - richardsliu
+            members:
+            - ewilderj
+            - bhupc
+            - danisla
+            - kiratp
+            - karthikv2k
+            - r2d4
+            - BenTheElder
+            - krzyzacy
+            - yebrahim
+            - IronPan
+            - ojarjur
+            - dlaqab
+            - cjwagner
+            - sarahmaddox
+            - vishh
+            - texasmichelle
+            - TheJaySmith
+            - fxue
+            - chrisheecho
+            - moxyoron
+            - yixinshi
+            - lluunn
+            - kunmingg
+            - ziamsyed
+            - sasha-gitg
+            privacy: closed
+          Intel:
+            description: Team at Intel contributing to Kubeflow.
+            maintainers:
+            - elsonrodriguez
+            members:
+            - nqn
+            - balajismaniam
+            - jose5918
+            - ashahba
+            privacy: closed
+          Red Hat:
+            description: Contributors from Red Hat
+            members:
+            - willb
+            - mattf
+            - erikerlandson
+            - tmckayus
+            - pdmack
+            privacy: closed
+          Seldon:
+            description: Engineers at Seldon contributing to Kubeflow
+            maintainers:
+            - cliveseldon
+            members:
+            - Maximophone
+            - gsunner
+            privacy: closed
+          caffe2-team:
+            description: Folks working on the caffe2 operator
+            members:
+            - carmark
+            - gaocegege
+            privacy: closed
+          caipe-dev:
+            description: 'One of the Google teams '
+            maintainers:
+            - jlewi
+            - frederick0329
+            privacy: closed
+          ci-bots:
+            description: Team for bots
+            members:
+            - k8s-ci-robot
+            - kubeflow-bot
+            privacy: closed
+          core-approvers:
+            description: A list of committers to the core repositories comprising Kubeflow.
+            maintainers:
+            - jlewi
+            members:
+            - willb
+            - tmckayus
+            - wbuchwalter
+            - gaocegege
+            - ScorpioCPH
+            - vishh
+            - DjangoPeng
+            - lluunn
+            privacy: closed
+          examples-approvers:
+            description: Approvers for the examples repository
+            maintainers:
+            - jlewi
+            members:
+            - wbuchwalter
+            - texasmichelle
+            - puneith
+            privacy: closed
+          kube-bench-team:
+            description: Kubeflow benchmarking
+            maintainers:
+            - jlewi
+            members:
+            - gaocegege
+            - xyhuang
+            privacy: closed
+          pipelines:
+            description: ""
+            maintainers:
+            - vicaire
+            members:
+            - neuromage
+            - yebrahim
+            - Ark-kun
+            - IronPan
+            - ajayalfred
+            - gaoning777
+            - paveldournov
+            - katieole
+            - qimingj
+            - rileyjbauer
+            - hongye-sun
+            privacy: closed
+          release-planning:
+            description: Team responsible for planning releases; has write permission on all
+              repos to manipulate issues
+            maintainers:
+            - jlewi
+            - chrisheecho
+            members:
+            - idvoretskyi
+            - carmine
+            privacy: closed
+          release-team:
+            description: Release team; permissions needed to create branches and other actions.
+            maintainers:
+            - jlewi
+            - richardsliu
+            members:
+            - kunmingg
+            privacy: closed
+          web-team:
+            description: Web site team
+            maintainers:
+            - ewilderj
+            members:
+            - inc0
+            privacy: closed
+

--- a/github-orgs/sync_org.sh
+++ b/github-orgs/sync_org.sh
@@ -24,7 +24,7 @@ if [ -z ${TOKEN_FILE} ]; then
 	exit 1	
 fi
 
-if [ -z ${CONFIR} ]; then
+if [ -z ${CONFIRM} ]; then
 	echo CONFIRM not set defaulting to dryrun mode
     CONFIRM=false
 fi	
@@ -33,5 +33,10 @@ cd ${TEST_INFRA_DIR}
 
 bazel run //prow/cmd/peribolos -- --fix-org-members --config-path ${DIR}/kubeflow/org.yaml \
 	--github-token-path ${TOKEN_FILE} \
-	--required-admins=jlewi,abhi-g,google-admin,googlebot,richardsliu,vicaire \
+	--required-admins=jlewi \
+	--required-admins=abhi-g \
+	--required-admins=google-admin \
+	--required-admins=googlebot \
+	--required-admins=richardsliu \
+	--required-admins=vicaire \
 	--confirm=${CONFIRM}

--- a/github-orgs/sync_org.sh
+++ b/github-orgs/sync_org.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# A simple bash script to sync the GitHub org.
+# See: https://github.com/kubernetes/test-infra/tree/master/prow/cmd/peribolos
+#
+# sync_org.sh <kubernets-test-infra-dir> <path-to-github-token>
+set -ex
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+TEST_INFRA_DIR=$1
+TOKEN_FILE=$2
+
+pushd .
+cd ${TEST_INFRA_DIR}
+
+bazel run //prow/cmd/peribolos -- --config-path ${DIR}/kubeflow/org.yaml \
+	--github-token-path ${TOKEN_FILE} \
+	--required-admins=jlewi,abhi-g,google-admin,googlebot,richardsliu,vicaire

--- a/github-orgs/sync_org.sh
+++ b/github-orgs/sync_org.sh
@@ -3,16 +3,35 @@
 # A simple bash script to sync the GitHub org.
 # See: https://github.com/kubernetes/test-infra/tree/master/prow/cmd/peribolos
 #
-# sync_org.sh <kubernets-test-infra-dir> <path-to-github-token>
+# sync_org.sh <kubernets-test-infra-dir> <path-to-github-token> <confirm>
 set -ex
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 TEST_INFRA_DIR=$1
 TOKEN_FILE=$2
+CONFIRM=$3
+usage() {
+	echo "sync_org.sh <kubernets-test-infra-dir> <path-to-github-token>"
+}
 
+if [ -z ${TEST_INFRA_DIR} ]; then
+	usage
+	exit 1	
+fi
+
+if [ -z ${TOKEN_FILE} ]; then
+	usage
+	exit 1	
+fi
+
+if [ -z ${CONFIR} ]; then
+	echo CONFIRM not set defaulting to dryrun mode
+    CONFIRM=false
+fi	
 pushd .
 cd ${TEST_INFRA_DIR}
 
-bazel run //prow/cmd/peribolos -- --config-path ${DIR}/kubeflow/org.yaml \
+bazel run //prow/cmd/peribolos -- --fix-org-members --config-path ${DIR}/kubeflow/org.yaml \
 	--github-token-path ${TOKEN_FILE} \
-	--required-admins=jlewi,abhi-g,google-admin,googlebot,richardsliu,vicaire
+	--required-admins=jlewi,abhi-g,google-admin,googlebot,richardsliu,vicaire \
+	--confirm=${CONFIRM}


### PR DESCRIPTION
Check in the Github org config.

* This is the first step of automating GitHub org membership kubeflow/community#55

* For now we should be able to do the sync by running peribolos manually.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/internal-acls/20)
<!-- Reviewable:end -->
