### PR TITLE
Add Yang to ci-team

### DIFF
--- a/ci-team.members.txt
+++ b/ci-team.members.txt
@@ -8,3 +8,4 @@ lunkai@google.com
 michellecasbon@google.com
 redhat-team@kubeflow.org
 wibuch@microsoft.com
+yangpa@google.com


### PR DESCRIPTION
* Yang needs to be able to build the images for code_search project.
  The GCB build is currently configured to use kubeflow-ci.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/internal-acls/24)
<!-- Reviewable:end -->
