### PR TITLE
Fix the GitHub org membership.

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -135,6 +135,7 @@ orgs:
         - sasha-gitg
         - sshrdp
         - ScorpioCPH
+        - sijieamoy
         - songole
         - suleisl2000
         - swiftdiaries
@@ -157,8 +158,9 @@ orgs:
         - yph152
         - YujiOshima
         - yupbank
+        - zhenghuiwang
         - ziamsyed
-        - zjj2wry
+        - zjj2wry        
         members_can_create_repositories: false
         name: Kubeflow
         teams:


### PR DESCRIPTION
@zhenghuiwang needs to be added to members not just team.

@siejiemoy is currently a member but not in the YAML file (He's part of Google's
UX team for Kubeflow).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/internal-acls/43)
<!-- Reviewable:end -->
