### PR TITLE
Remove unused core-approvers and examples-approvers teams

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -312,29 +312,6 @@ orgs:
             - k8s-ci-robot
             - kubeflow-bot
             privacy: closed
-          core-approvers:
-            description: A list of committers to the core repositories comprising Kubeflow.
-            maintainers:
-            - jlewi
-            members:
-            - willb
-            - tmckayus
-            - wbuchwalter
-            - gaocegege
-            - ScorpioCPH
-            - vishh
-            - DjangoPeng
-            - lluunn
-            privacy: closed
-          examples-approvers:
-            description: Approvers for the examples repository
-            maintainers:
-            - jlewi
-            members:
-            - wbuchwalter
-            - texasmichelle
-            - puneith
-            privacy: closed
           kube-bench-team:
             description: Kubeflow benchmarking
             maintainers:


### PR DESCRIPTION
These groups are not used anymore. See https://github.com/kubeflow/community/issues/264 for context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/internal-acls/97)
<!-- Reviewable:end -->
