### PR TITLE
Remove vicaire as an admin

### DIFF
--- a/github-orgs/sync_org.sh
+++ b/github-orgs/sync_org.sh
@@ -74,7 +74,6 @@ elif [ "${action}" == "sync" ]; then
 		--required-admins=google-admin \
 		--required-admins=googlebot \
 		--required-admins=richardsliu \
-		--required-admins=vicaire \
 		--confirm=${confirm}
     echo "Note: if dryrun=true you might get errors updating groups if the group doesn't exist"
 else 


### PR DESCRIPTION
The sync_org.sh script fails because it requires the admins to be member of the org which vicaire isn't anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/internal-acls/127)
<!-- Reviewable:end -->
