### PR TITLE
cleanup memberships for vicaire

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -249,7 +249,6 @@ orgs:
             maintainers:
             - jlewi
             - abhi-g
-            - vicaire
             - richardsliu
             members:
             - ellis-bigelow
@@ -341,7 +340,7 @@ orgs:
           pipelines:
             description: ""
             maintainers:
-            - vicaire
+            - IronPan
             members:
             - neuromage
             - yebrahim


### PR DESCRIPTION
cleaning up vicaire's membership otherwise throws up errors on running org syncs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/internal-acls/128)
<!-- Reviewable:end -->
