### PR TITLE
Create a group for people with permission to add issues to projects.

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -345,7 +345,6 @@ orgs:
             - neuromage
             - yebrahim
             - Ark-kun
-            - IronPan
             - ajayalfred
             - gaoning777
             - paveldournov
@@ -355,6 +354,16 @@ orgs:
             - hongye-sun
             - jingzhang36
             - numerology
+            privacy: closed
+          project-maintainers:
+            description: Team responsible for managing project kanban boards
+            maintainers:
+            - jlewi
+            - abhi-g
+            members:            
+            - carmine
+            - kkasravi
+            - vkoukis
             privacy: closed
           release-planning:
             description: Team responsible for planning releases; has write permission on all


### PR DESCRIPTION
* The prow project bot needs a project maintainers group.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/internal-acls/129)
<!-- Reviewable:end -->
