### PR TITLE
rollback jinchihe to IBM account

### DIFF
--- a/example-maintainers.members.txt
+++ b/example-maintainers.members.txt
@@ -1,3 +1,3 @@
 chasm@google.com
+hejinchi@cn.ibm.com
 jinchihe@gmail.com
-


### PR DESCRIPTION
As just discussed in the meeting with @jlewi, for the the glound account can be my IBM email, rollback jinchihe to IBM account in the example-maintainers.members.txt.
```
(python3) hejinchideMacBook-Pro:internal-acls hejinchi$ gcloud info |grep -i account
Account: [hejinchi@cn.ibm.com]
    account: [hejinchi@cn.ibm.com]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/internal-acls/133)
<!-- Reviewable:end -->
