### PR TITLE
Fixed broken org.yaml due to missing entries in org members. Added manual test.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ DESCRIPTION="Some group description"
   name ${GROUP_NAME} description "${DESCRIPTION}" \
   allow_external_members true
 ```
+
+Currently after modifying org.yaml, pytest should be manually run in
+github-orgs directory to verify the change. This test will be run
+automatically in a future change.

--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -99,6 +99,7 @@ orgs:
         - hougangliu
         - hmtai
         - idvoretskyi
+        - imjohnbo
         - inc0
         - ioandr
         - IronPan

--- a/github-orgs/test_org_yaml.py
+++ b/github-orgs/test_org_yaml.py
@@ -1,0 +1,27 @@
+"""Validate kubeflow/org.yaml file.
+
+The tests in this file validates:
+  - org.yaml is a valid YAML file
+  - All team maintainers and members appear under org admins or members
+"""
+
+import yaml
+
+ORG_YAML = "kubeflow/org.yaml"
+
+def test_team_member_is_in_org():
+  with open(ORG_YAML) as stream:
+    org_data = yaml.safe_load(stream)
+    
+    for org_name, org in org_data["orgs"].items():
+      org_members = org["members"]
+      org_admins = org["admins"]
+
+      for team_name, team in org["teams"].items():
+        # Verify both all groups under team
+        for group_name in ["maintainers", "members"]:
+          if group_name in team:
+            for team_member in team[group_name]:
+              assert team_member in org_members or team_member in org_admins, \
+                "{} (team {}) not an admin or member of org {}".format(
+                  team_member, team_name, org_name)


### PR DESCRIPTION
The problem was that one of the newly added team members was not an admin or member of Kubeflow org. Fixed the membership. Updated README as well to include manual tests.

Fixes https://github.com/kubeflow/internal-acls/issues/148

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/internal-acls/149)
<!-- Reviewable:end -->
