### PR TITLE
Add jinchihe to ci-team

### DIFF
--- a/ci-team.members.txt
+++ b/ci-team.members.txt
@@ -5,6 +5,7 @@ cc@seldon.io
 deyuan@caicloud.io
 gaoce@caicloud.io
 google-team@kubeflow.org
+hejinchi@cn.ibm.com
 holden.karau@gmail.com
 kam.d.kasravi@intel.com
 kunming@google.com


### PR DESCRIPTION
I'm making the E2E testing for KFServing now (https://github.com/kubeflow/kfserving/pull/383), need to add ci-team for debug easily. And I'm maintainer for other repos such as Fairing, can debug the ci/cd testing if needed. Thanks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/internal-acls/163)
<!-- Reviewable:end -->
