### PR TITLE
Add Scott Lee to ci-team

### DIFF
--- a/ci-team.members.txt
+++ b/ci-team.members.txt
@@ -11,5 +11,6 @@ kunming@google.com
 lunkai@google.com
 michellecasbon@google.com
 redhat-team@kubeflow.org
+scottleehello@gmail.com
 wibuch@microsoft.com
 yangpa@google.com


### PR DESCRIPTION
Working on https://github.com/GoogleCloudPlatform/oss-test-infra/pull/93#issuecomment-535367394 to move Kubeflow jobs to oss-test-infra.

/cc @jlewi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/internal-acls/167)
<!-- Reviewable:end -->
