### PR TITLE
update ci-viewer team to get pods log

### DIFF
--- a/gcp_iam_policies/kubeflow-ci-deployment.iam.policy.yaml
+++ b/gcp_iam_policies/kubeflow-ci-deployment.iam.policy.yaml
@@ -876,5 +876,8 @@ bindings:
 - members:
   - group:ci-viewer@kubeflow.org
   role: roles/container.viewer
+- members:
+  - group:ci-viewer@kubeflow.org
+  role: roles/serviceusage.serviceUsageConsumer
 etag: BwWUWYqtpGM=
 version: 1

--- a/gcp_iam_policies/kubeflow-ci.iam.policy.yaml
+++ b/gcp_iam_policies/kubeflow-ci.iam.policy.yaml
@@ -132,6 +132,9 @@ bindings:
   - group:ci-viewer@kubeflow.org
   role: roles/container.viewer
 - members:
+  - group:ci-viewer@kubeflow.org
+  role: roles/serviceusage.serviceUsageConsumer
+- members:
   - serviceAccount:kf-vmaster-n00-user@kubeflow-ci.iam.gserviceaccount.com
   - serviceAccount:kfctl-fc5b-user@kubeflow-ci.iam.gserviceaccount.com
   - serviceAccount:kubeflow-ci-fairing-user@kubeflow-ci.iam.gserviceaccount.com


### PR DESCRIPTION
fixes: #179 

@jlewi As we discussed by Slack, ci-viewer team cannot get the log of pods:
```
[root@jinchi1 ~]# kubectl logs kfserving-controller-manager-0 -n kfserving-system
Error from server (Forbidden): pods "kfserving-controller-manager-0" is forbidden: User "hejinchi@cn.ibm.com" cannot get resource "pods/log" in API group "" in the namespace "kfserving-system": Required "container.pods.getLogs" permission.
```

This PR adds the IAM policy role `roles/serviceusage.serviceUsageConsumer`. With this role pod logs can be fetched from stackdriver either via the UI or via gcloud. This role is needed to allow stackdriver usage to be billed to that project.

This still doesn't allow `kubectl logs` because that requires container.developer permission.

~~From the error message, we need the `container.pods.getLogs` permission, but checked the `roles/container.viewer`, does not have `container.pods.getLogs` permission, but the `roles/container.developer` has `container.pods.*`. see [here](https://cloud.google.com/iam/docs/understanding-roles#kubernetes-engine-roles) for role details. Seems can get logs, so I update from `container.viewer` to `developer`. ~~

~~In fact I'm a little hesitant since this will extent the permission to deployer but we really need get logs, that's import for investigation problems :-).~~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/internal-acls/180)
<!-- Reviewable:end -->
