### PR TITLE
Add teams for xgboost-operator, mpi-operator, and kubeflow/common

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -363,6 +363,31 @@ orgs:
             - gaocegege
             - xyhuang
             privacy: closed
+          mpi-operator-team:
+            description: Team working on MPI Operator
+            maintainers:
+            - anfeng
+            - rongou
+            - terrytangyuan
+            members:
+            - cheyang
+            - everpeace
+            - gaocegege
+            - fisherxu
+            privacy: closed
+          xgboost-operator-team:
+            description: Team working on XGBoost Operator
+            maintainers:
+            - terrytangyuan
+            privacy: closed
+          common-team:
+            description: Team working on kubeflow/common
+            maintainers:
+            - richardsliu
+            - johnugeorge
+            - gaocegege
+            - terrytangyuan
+            privacy: closed
           pipelines:
             description: ""
             maintainers:

--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -379,6 +379,9 @@ orgs:
             description: Team working on XGBoost Operator
             maintainers:
             - terrytangyuan
+            members:
+            - johnugeorge
+            - richardsliu
             privacy: closed
           common-team:
             description: Team working on kubeflow/common


### PR DESCRIPTION
Note that only people in Kubeflow Github org are included. Other developers will be added later once they become members.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/internal-acls/182)
<!-- Reviewable:end -->
