### PR TITLE
Remove members added to GitHub org for WtD AU 2019 doc fixit

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -28,7 +28,6 @@ orgs:
         - ajayalfred
         - ajchili
         - Akado2009
-        - alecglassford
         - alexmt
         - alsrgv
         - amsaha
@@ -177,7 +176,6 @@ orgs:
         - randxie
         - rebeccamcfadden
         - rileyjbauer
-        - rionam
         - rlenferink
         - rmgogogo
         - rongou


### PR DESCRIPTION
This reverts https://github.com/kubeflow/internal-acls/pull/187 (commit d7004f6e3478513bb4514d91b9272cd031592e63) now that the event has passed.

Related: https://github.com/kubeflow/website/pull/1418

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/internal-acls/191)
<!-- Reviewable:end -->
