### PR TITLE
Add the prow bot for the google repo to ci team.

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -92,6 +92,7 @@ orgs:
         - gaocegege
         - gaoning777
         - garganubhav
+        - google-oss-robot
         - greynutw
         - gsunner
         - gyliu513
@@ -355,6 +356,7 @@ orgs:
           ci-bots:
             description: Team for bots
             members:
+            - google-oss-robot
             - k8s-ci-robot
             - kubeflow-bot
             privacy: closed


### PR DESCRIPTION
Reference: kubernetes/test-infra#14343

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/internal-acls/193)
<!-- Reviewable:end -->
