### PR TITLE
Remove dakoner from kubeflow github org.

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -64,7 +64,6 @@ orgs:
         - cspavlou
         - cwbeitel
         - danisla
-        - dakoner
         - ddutta
         - ddysher
         - derekhh


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/internal-acls/222)
<!-- Reviewable:end -->
