### PR TITLE
Grant admin access to mpi, xgboost, common teams

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -401,6 +401,8 @@ orgs:
             - everpeace
             - gaocegege
             - fisherxu
+            repos:
+                mpi-operator: admin
             privacy: closed
           xgboost-operator-team:
             description: Team working on XGBoost Operator
@@ -409,6 +411,8 @@ orgs:
             members:
             - johnugeorge
             - richardsliu
+            repos:
+                xgboost-operator: admin
             privacy: closed
           common-team:
             description: Team working on kubeflow/common
@@ -417,6 +421,8 @@ orgs:
             - johnugeorge
             - gaocegege
             - terrytangyuan
+            repos:
+                common: admin
             privacy: closed
           pipelines:
             description: ""


### PR DESCRIPTION
/cc @jlewi per our discussion in https://github.com/kubeflow/internal-acls/issues/228. This should give admin access to maintainers of these repos.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>