### PR TITLE
Adding berndverst as kubeflow org member

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -46,6 +46,7 @@ orgs:
         - balajismaniam
         - beberg
         - BenTheElder
+        - berndverst
         - bhupc
         - bikramnehra
         - Bobgy


### PR DESCRIPTION
Adding myself as a member.

- 40 contributions on GitHub (according to Graphana), mostly Azure related
- Active on community Slack helping with Azure and non-Azure questions
- Started coordinating Kubeflow contributions and documentation internally within Microsoft