### PR TITLE
Adds ian coffey to test infra team list

### DIFF
--- a/ci-viewer.members.txt
+++ b/ci-viewer.members.txt
@@ -5,6 +5,7 @@ dsun20@bloomberg.net
 gaoce@caicloud.io
 hejinchi@cn.ibm.com
 holden.karau@gmail.com
+icoffey@vmware.com
 ifilonenko@bloomberg.net
 iman.tabrizian@gmail.com
 nrchakradhar379@gmail.com

--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -114,6 +114,7 @@ orgs:
         - hongye-sun
         - hougangliu
         - hmtai
+        - iancoffey
         - idvoretskyi
         - imjohnbo
         - inc0


### PR DESCRIPTION
Requesting access so I can troubleshoot this broken examples situation.

https://github.com/kubeflow/examples/pull/795#issuecomment-629418401