### PR TITLE
Add AWS team and add Jeffwan to project-maintainers

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -510,6 +510,16 @@ orgs:
             - ohmystack
             - ScorpioCPH
             privacy: closed
+          AWS:
+            description: Team of members from AWS
+            maintainers:
+            - Jeffwan
+            members:
+            - akartsky
+            - PatrickXYS
+            - RedbackThomson
+            - surajkota
+            privacy: closed
           Caicloud:
             description: Team of members from Caicloud
             maintainers:
@@ -675,6 +685,7 @@ orgs:
           common-team:
             description: Team working on kubeflow/common
             maintainers:
+            - Jeffwan
             - johnugeorge
             - terrytangyuan
             - gaocegege
@@ -843,6 +854,7 @@ orgs:
               examples: write
               fairing: write
               katib: write
+              kfctl: write
               kfserving: write
               kubebench: write
               kubeflow: write


### PR DESCRIPTION
1. Add AWS team for internal discussion
2. Add Jeffwan@ to kubeflow/common team
3. Add kfctl to `release-team` scope.