### PR TITLE
Add back members from Ant Financial that went missing

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -507,8 +507,11 @@ orgs:
             - ywskycn
             - terrytangyuan
             members:
-            - ohmystack
             - ScorpioCPH
+            - merlintang
+            - ohmystack
+            - sperlingxx
+            - zhujl1991
             privacy: closed
           Caicloud:
             description: Team of members from Caicloud


### PR DESCRIPTION
These members went missing after https://github.com/kubeflow/internal-acls/pull/250.