### PR TITLE
chore: Remove outdated members and add fate to cibots

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -532,11 +532,7 @@ orgs:
             - ddysher
             - gaocegege
             members:
-            - lienhua34
             - codeflitting
-            - wuchunghsuan
-            - zjj2wry
-            - yph152
             privacy: closed
           Cisco:
             description: Team @Cisco contributing to KubeFlow
@@ -688,6 +684,7 @@ orgs:
               triage-issues: read
               website: write
               xgboost-operator: write
+              fate-operator: write
           common-team:
             description: Team working on kubeflow/common
             maintainers:


### PR DESCRIPTION
This PR is to:

- Remove outdated members in Caicloud
- Add fate-operator to ci-bots team

Signed-off-by: Ce Gao <gaoce@caicloud.io>