### PR TITLE
Update org.yaml

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -636,6 +636,20 @@ orgs:
             privacy: closed
             repos:
               example-seldon: write
+          blog-team:
+            description: Team responsible for maintaining the kubeflow blog
+            maintainers:
+            - jlewi
+            - hamelsmu
+            members:
+            - jbottum
+            - jtfogarty
+            - terrytangyuan
+            - StefanoFioravanzo
+            privacy: closed
+            repos:
+              blog: write
+              fastpages: write
           caffe2-team:
             description: Folks working on the caffe2 operator
             members:


### PR DESCRIPTION
cc: @jlewi 

I propose that we start all over again with `kubeflow/fastpages` and re-create and name it `kubeflow/blog` so it is easier to understand what the repo is about.  I went ahead and put both names here but just starting the PR to get things going

I think you should delete the repo and do the process of pulling the template again so you don't have to change all the configuration files everywhere.  It will be much easier to just recreate the repo from the template and name it `blog`