### PR TITLE
Add k8s-ci-robot as Kubeflow admin

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -9,6 +9,7 @@ orgs:
         - google-admin
         - googlebot
         - jlewi
+        - k8s-ci-robot
         - richardsliu
         - theadactyl
         billing_email: vishnukanan@gmail.com


### PR DESCRIPTION
Because of https://github.com/kubeflow/pipelines/issues/1653#issuecomment-662211749, k8s-ci-bot needs org admin permission to do its job.

For security concerns, k8s-ci-bot is also kubernetes organization's admin, so we think it's fine https://github.com/kubeflow/pipelines/issues/1653#issuecomment-668625178