### PR TITLE
Update org.yaml

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -24,6 +24,7 @@ orgs:
         members:
         - 8bitmp3
         - abcdefgs0324
+        - abhi-g
         - abkosar
         - achalshant
         - adrian555
@@ -209,6 +210,7 @@ orgs:
         - Realsen
         - rebeccamcfadden
         - RedbackThomson
+        - richardsliu
         - rlenferink
         - rmgogogo
         - rongou
@@ -239,6 +241,7 @@ orgs:
         - Tabrizian
         - terrytangyuan
         - texasmichelle
+        - theadactyl
         - thedriftofwords
         - TheJaySmith
         - tmckayus


### PR DESCRIPTION
Adding abhi-g, richardsliu, theadactyl back as org members.

To fix github sync error: "Configuration failed: failed to configure kubeflow members: all team members/maintainers must also be org members: abhi-g, richardsliu, theadactyl","time":"2020-08-15T01:46:09Z"

/assign @james-jwu @Bobgy @jlewi 