### PR TITLE
Update org.yaml - remove bobgy, james-jwu, k8s-ci-robot, rmgogogo from org members

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -54,7 +54,6 @@ orgs:
         - bhupc
         - bikramnehra
         - bmorphism
-        - Bobgy
         - c-bata
         - carmark
         - carmine
@@ -125,7 +124,6 @@ orgs:
         - inc0
         - ioandr
         - IronPan
-        - james-jwu
         - janeman98
         - jasonliu747
         - jbottum
@@ -145,7 +143,6 @@ orgs:
         - josiemundi
         - jtfogarty
         - jzp1025
-        - k8s-ci-robot
         - kandrio98
         - karlschriek
         - karthikv2k
@@ -212,7 +209,6 @@ orgs:
         - RedbackThomson
         - richardsliu
         - rlenferink
-        - rmgogogo
         - rongou
         - rpasricha
         - rui5i


### PR DESCRIPTION
Remove bobgy, james-jwu, k8s-ci-robot, rmgogogo from org members, as they were added to org admins

To fix github sync error: "Configuration failed: failed to configure kubeflow members: users in both roles: bobgy, james-jwu, k8s-ci-robot, rmgogogo"

/assign @Bobgy @james-jwu @rmgogogo