### PR TITLE
Add AutoML and Training WG teams

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -654,6 +654,15 @@ orgs:
             privacy: closed
             repos:
               example-seldon: write
+          automl-leads:
+            description: Team for AutoML working group leads; permissions needed to create branches and other actions.
+            maintainers:
+            - andreyvelich
+            - gaocegege
+            - johnugeorge
+            privacy: closed
+            repos:
+              katib: write
           blog-admin-team:
             description: Team responsible for administering and troubleshooting issues with the kubeflow blog
             maintainers:
@@ -943,25 +952,7 @@ orgs:
               tf-operator: write
               website: write
               xgboost-operator: write
-          web-team:
-            description: Web site team
-            maintainers:
-            - ewilderj
-            members:
-            - inc0
-            privacy: closed
-            repos:
-              website: write
-          wg-automl-leads:
-            description: Team for AutoML working group leads; permissions needed to create branches and other actions.
-            maintainers:
-            - andreyvelich
-            - gaocegege
-            - johnugeorge
-            privacy: closed
-            repos:
-              katib: write
-          wg-training-leads:
+          training-leads:
             description: Team for Training working group leads; permissions needed to create branches and other actions.
             maintainers:
             - andreyvelich
@@ -981,6 +972,15 @@ orgs:
               fate-operator: write
               caffe2-operator: write
               common: write
+          web-team:
+            description: Web site team
+            maintainers:
+            - ewilderj
+            members:
+            - inc0
+            privacy: closed
+            repos:
+              website: write
           xgboost-operator-team:
             description: Team working on XGBoost Operator
             maintainers:

--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -961,6 +961,35 @@ orgs:
             privacy: closed
             repos:
               website: write
+          wg-automl-leads:
+            description: Team for AutoML working group leads; permissions needed to create branches and other actions.
+            maintainers:
+            - andreyvelich
+            - gaocegege
+            - johnugeorge
+            privacy: closed
+            repos:
+              katib: write
+          wg-training-leads:
+            description: Team for Training working group leads; permissions needed to create branches and other actions.
+            maintainers:
+            - andreyvelich
+            - ChanYiLin
+            - gaocegege
+            - Jeffwan
+            - johnugeorge
+            - terrytangyuan
+            privacy: closed
+            repos:
+              tf-operator: write
+              pytorch-operator: write
+              mpi-operator: write
+              xgboost-operator: write
+              mxnet-operator: write
+              chainer-operator: write
+              fate-operator: write
+              caffe2-operator: write
+              common: write
           xgboost-operator-team:
             description: Team working on XGBoost Operator
             maintainers:

--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -762,15 +762,6 @@ orgs:
             privacy: closed
             repos:
               fairing: write
-          katib-release:
-            description: Team working on Katib release; permissions needed to create branches and other actions.
-            maintainers:
-            - andreyvelich
-            - gaocegege
-            - johnugeorge
-            privacy: closed
-            repos:
-              katib: write
           kfctl-release:
             description: Team that will cut kfctl releases
             maintainers:


### PR DESCRIPTION
Related https://github.com/kubeflow/community/issues/399.

I added team for Training and AutoML WG and remove katib-release team since it is redundant.
I give write permission to appropriate repos.

/cc @ChanYiLin @gaocegege @johnugeorge @terrytangyuan @Jeffwan 
/assign @jlewi 