### PR TITLE
Remove Googlers no longer maintaining kf-kcc infra.

### DIFF
--- a/kf-kcc-admins.members.txt
+++ b/kf-kcc-admins.members.txt
@@ -1,11 +1,4 @@
-alexbu@google.com
 derekhh@snap.com
 hejinchi@cn.ibm.com
-jlew@kubeflow.org
-kunming@google.com
-maqiuyu@google.com
 google-kubeflow-admins@kubeflow.org
-ricliu@google.com
-rleidle@google.com
 scottleehello@gmail.com
-yangpa@google.com


### PR DESCRIPTION
Related to: kubeflow/community-infra#14