### PR TITLE
Add @andreyvelich to kf-kcc members

### DIFF
--- a/kf-kcc-admins.members.txt
+++ b/kf-kcc-admins.members.txt
@@ -1,3 +1,4 @@
+andrey.velichkevich@gmail.com
 derekhh@snap.com
 hejinchi@cn.ibm.com
 google-kubeflow-admins@kubeflow.org


### PR DESCRIPTION
I added myself to kf-kcc members from @kubeflow/automl-leads side to help maintaining CI/CD for Training and AutoML WG.
Related: https://github.com/kubeflow/community-infra/issues/14.

/assign @jlewi 
/cc @gaocegege @johnugeorge 
