### PR TITLE
Add "wg-" prefix to the leads mailing lists.

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -654,7 +654,7 @@ orgs:
             privacy: closed
             repos:
               example-seldon: write
-          automl-leads:
+          wg-automl-leads:
             description: Team for AutoML working group leads; permissions needed to create branches and other actions.
             maintainers:
             - andreyvelich
@@ -803,6 +803,18 @@ orgs:
             privacy: closed
             repos:
               mpi-operator: write
+          wg-serving-leads:
+            description: Leads for KFServing workgroup
+            maintainers:
+            - ellistarn
+            - cliveseldon
+            - animeshsingh
+            - yuzisun
+            - rakelkar
+            privacy: closed
+            repos:
+              kfserving: admin
+          # TODO(wg-kfserving-leads): Can we just use wg-kfserving-leads
           kfserving-owners:
             description: Team working on kfserving
             maintainers:
@@ -952,7 +964,7 @@ orgs:
               tf-operator: write
               website: write
               xgboost-operator: write
-          training-leads:
+          wg-training-leads:
             description: Team for Training working group leads; permissions needed to create branches and other actions.
             maintainers:
             - andreyvelich

--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -654,15 +654,6 @@ orgs:
             privacy: closed
             repos:
               example-seldon: write
-          wg-automl-leads:
-            description: Team for AutoML working group leads; permissions needed to create branches and other actions.
-            maintainers:
-            - andreyvelich
-            - gaocegege
-            - johnugeorge
-            privacy: closed
-            repos:
-              katib: write
           blog-admin-team:
             description: Team responsible for administering and troubleshooting issues with the kubeflow blog
             maintainers:
@@ -803,17 +794,6 @@ orgs:
             privacy: closed
             repos:
               mpi-operator: write
-          wg-serving-leads:
-            description: Leads for KFServing workgroup
-            maintainers:
-            - ellistarn
-            - cliveseldon
-            - animeshsingh
-            - yuzisun
-            - rakelkar
-            privacy: closed
-            repos:
-              kfserving: admin
           # TODO(wg-kfserving-leads): Can we just use wg-kfserving-leads
           kfserving-owners:
             description: Team working on kfserving
@@ -964,6 +944,26 @@ orgs:
               tf-operator: write
               website: write
               xgboost-operator: write
+          wg-automl-leads:
+            description: Team for AutoML working group leads; permissions needed to create branches and other actions.
+            maintainers:
+            - andreyvelich
+            - gaocegege
+            - johnugeorge
+            privacy: closed
+            repos:
+              katib: write            
+          wg-serving-leads:
+            description: Leads for KFServing workgroup
+            maintainers:
+            - ellistarn
+            - cliveseldon
+            - animeshsingh
+            - yuzisun
+            - rakelkar
+            privacy: closed
+            repos:
+              kfserving: admin
           wg-training-leads:
             description: Team for Training working group leads; permissions needed to create branches and other actions.
             maintainers:


### PR DESCRIPTION
* @andreyvelich originally had the prefix in #318 and I suggested removing
  it because it was redundant.

* I subsequently checked and using the wg is consistent with what Kubernetes
  does and is consistent with kubeflow/community#401

* Including the wg prefix has the following advantage

  * Easily distinguish between groups for workgroups and sigs and other purposes
  * Auto complete makes it easy to identify all groups.