### PR TITLE
Remove 'karkumar' from org.yaml

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -148,7 +148,6 @@ orgs:
         - jtfogarty
         - jzp1025
         - kandrio98
-        - karkumar
         - karlschriek
         - karthikv2k
         - katieole
@@ -635,7 +634,6 @@ orgs:
             - dushyanthsc
             - sasha-gitg
             - james-jwu
-            - karkumar
             privacy: closed
           google-admins:
             description: Googlers to ping for help regarding Kubeflow GitHub org or gsuite org
@@ -877,7 +875,6 @@ orgs:
             - dushyanthsc
             - hongye-sun
             - james-jwu
-            - karkumar
             privacy: closed
             repos:
               pipelines: write

--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -148,6 +148,7 @@ orgs:
         - jtfogarty
         - jzp1025
         - kandrio98
+        - karkumar
         - karlschriek
         - karthikv2k
         - katieole


### PR DESCRIPTION
To fix broken Github sync: "Configuration failed: failed to configure kubeflow members: all team members/maintainers must also be org members: karkumar"

Fixes #344 