### PR TITLE
Add pvaneck as member

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -205,6 +205,7 @@ orgs:
         - prodonjs
         - pugangxa
         - puneith
+        - pvaneck
         - pvellanki
         - pyalex
         - quanjielin


### PR DESCRIPTION
Currently active in the control plane for Kubeflow as a part of IBM

Some contributions include:
https://github.com/kubeflow/manifests/pulls?q=is%3Apr+author%3Apvaneck
https://github.com/kubeflow/kfserving/pull/1113