### PR TITLE
Grant PatrickXYS Temporary Admin Access to katib and pytorch repos

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -995,6 +995,14 @@ orgs:
               tf-operator: write
               website: write
               xgboost-operator: write
+          temporary-admin-members:
+            description: Team for temporary admin access; Will be Removed at 01/20/2021
+            members:
+            - PatrickXYS
+            privacy: closed
+            repos:
+              katib: admin
+              pytorch-operator: admin
           third-party-bots:
             description: Team for third party bots
             members:


### PR DESCRIPTION
Given the discussions we have in https://github.com/kubeflow/internal-acls/issues/348, we want to save some efforts from @Bobgy ,

this PR is to grant temporary admin access to katib and pytorch-operator repos for debugging AWS Shared Test-infra.

Here is the short story:

1. Add PatrickXYS@ repo admin
2. Debug AWS Shared Test-infra in katib and pytorch repos
3. After done in both repos, remove PatrickXYS@ from repo admin. 