### PR TITLE
Grant aws-kf-ci-bot write access to kfserving

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -1005,11 +1005,12 @@ orgs:
               pytorch-operator: admin
           third-party-bots:
             description: Team for third party bots
-            members:
+            maintainers:
             - aws-kf-ci-bot
             privacy: closed
             repos:
               katib: write
+              kfserving: write
               pytorch-operator: write
           wg-automl-leads:
             description: Team for AutoML working group leads; permissions needed to create branches and other actions.


### PR DESCRIPTION
Given the offline discussion with Serving WG TL:

@animeshsingh @yuzisun @ellistarn 

We have agreed to start migration work to Shared Test-infra for Kfserving.