### PR TITLE
PSG transition: jlewi -> bobgy

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -937,6 +937,7 @@ orgs:
           project-steering-group:
             description: Project steering group as defined by Kubeflow governance
             members:
+            - Bobgy
             - jlewi
             - paveldournov
             - theadactyl


### PR DESCRIPTION
@bobgy has taken over most of the day to day responsibilities for supporting
the Kubeflow project so that I can focus on other projects.

The current plan is for @bobgy to take over for me on the project steering
group.

I will step back once @bobgy has had a chance to ramp up.

I would like to finish bootstrapping the WGs before doing so.

The main work remaining on that side is

1. The pending deployments WG
1. Resolving what to do about a control plane WG and some applications
   currently lacking owners.