### PR TITLE
Randomized team name to fix issue

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -1004,7 +1004,7 @@ orgs:
             repos:
               katib: admin
               pytorch-operator: admin
-          third-party-bots:
+          third-party-bots-1321:
             description: Team for third party bots
             maintainers:
             - aws-kf-ci-bot

--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -1011,8 +1011,12 @@ orgs:
             privacy: closed
             repos:
               katib: write
+              kfctl: write
               kfserving: write
+              manifests: write
               pytorch-operator: write
+              tf-operator: write
+              xgboost-operator: write
           wg-automl-leads:
             description: Team for AutoML working group leads; permissions needed to create branches and other actions.
             maintainers:


### PR DESCRIPTION
Resolve #361 

Given the fact that `third-party-bots` team is not included in kubeflow org, but appears in the UI,

we want to randomize team name to see if this can fix the issue

**Another change**

For kubeflow 1.2 release, we want to enable E2E test for kfctl + manifests, thus, add two repos' permission.

Besides that, we left two Training-WG's repo: xgboost + tf-operator.