### PR TITLE
Add third-party-bots with caffe2-operator access

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -1012,12 +1012,6 @@ orgs:
             privacy: closed
             repos:
               katib: write
-              kfctl: write
-              kfserving: write
-              manifests: write
-              pytorch-operator: write
-              tf-operator: write
-              xgboost-operator: write
           wg-automl-leads:
             description: Team for AutoML working group leads; permissions needed to create branches and other actions.
             maintainers:


### PR DESCRIPTION
Since we have a blocking sync issue as described #361 ,

this time we add one repo into the list, and meanwhile check the log to see how it goes.

This should give us more information to debug further.

/cc @jlewi 