### PR TITLE
Move the K8s manifests for github sync into internal-acls.

### DIFF
--- a/github-orgs/manifests/Makefile
+++ b/github-orgs/manifests/Makefile
@@ -1,0 +1,11 @@
+PROJECT := kubeflow-admin
+IMG = gcr.io/$(PROJECT)/peribolos
+
+
+TAG := $(shell date +v%Y%m%d)-$(shell git describe --always --dirty)
+TAG := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)-$(shell git diff | shasum -a256 | cut -c -6)
+DIR := ${CURDIR}
+
+# Create a config map containing the python code to valide the image
+create-config-map:
+	kubectl -n github-admin create configmap github-sync-code --from-file=validate_config.py

--- a/github-orgs/manifests/README.md
+++ b/github-orgs/manifests/README.md
@@ -1,0 +1,24 @@
+# Auto sync for GitHub org
+
+* **project**: kubeflow-admin
+* **cluster**: kf-admin-cluster 
+* **namespace**: github-admin
+
+## Github Token
+
+We need a GitHub token with admin:org priveleges
+
+```
+kubectl -n github-admin create secret generic github-org-admin-token --from-file=github_token=<PATH TO TOKEN>
+```
+
+* We are currently using the token **peribolos-kubeflow-org-admin** owned by jlewi
+
+
+## Validate config map
+
+We use a config map to provide the python code used to validate the config
+
+```
+make create-config-map
+```

--- a/github-orgs/manifests/github-sync-cron-job.yaml
+++ b/github-orgs/manifests/github-sync-cron-job.yaml
@@ -1,0 +1,80 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: github-sync
+  namespace: github-admin
+spec:
+  concurrencyPolicy: Forbid
+  # Run every 10 minutes
+  schedule: "*/10 * * * *"
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            job: github-sync
+            version: master
+        # Keep in sync with github-sync-job.yaml
+        spec:
+          initContainers:
+          - name: checkout
+            command:
+            - /usr/local/bin/checkout_repos.sh
+            - --repos=kubeflow/internal-acls@HEAD
+            - --src_dir=/src
+            image: gcr.io/kubeflow-admin/test-worker:v20190723-0a32b01-dirty-b7e34b
+            volumeMounts:
+            - mountPath: /src
+              name: src
+          # Validate the config to make sure insecure changes (e.g. addmins unallowed admins is blocked)
+          - name: validate
+            command:
+            - python 
+            - /code/validate_config.py
+            - check-config 
+            - /src/kubeflow/internal-acls/github-orgs/kubeflow/org.yaml 
+            image: gcr.io/kubeflow-admin/test-worker:v20190723-0a32b01-dirty-b7e34b
+            volumeMounts:
+            - mountPath: /src
+              name: src
+            - mountPath: /code
+              name: validate-code
+          containers:
+          - name: sync
+            image: gcr.io/k8s-prow/peribolos@sha256:cb771295078f0a7353f375d39242ecafadcfc46650efb8a5f0adfa10b3f8c050
+            env:
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: github-org-admin-token
+                  key: github_token
+            command:
+            - /app/prow/cmd/peribolos/app.binary.runfiles/io_k8s_test_infra/prow/cmd/peribolos/linux_amd64_pure_stripped/app.binary  
+            - --fix-teams 
+            - --fix-team-members 
+            - --fix-org-members 
+            - --fix-team-repos
+            - --config-path=/src/kubeflow/internal-acls/github-orgs/kubeflow/org.yaml
+            - --github-token-path=/secret/github-token/github_token
+            - --required-admins=jlewi
+            - --required-admins=james-jwu
+            - --required-admins=google-admin
+            - --required-admins=googlebot
+            - --confirm=true
+            volumeMounts:
+            - name: github-token
+              mountPath: /secret/github-token
+              readOnly: true
+            - mountPath: /src
+              name: src
+          restartPolicy: Never
+          volumes:
+          - name: github-token
+            secret:
+              secretName: github-org-admin-token
+          - name: src
+            emptyDir: {}
+          - name: validate-code
+            configMap:
+              name: github-sync-code 

--- a/github-orgs/manifests/github-sync-job.yaml
+++ b/github-orgs/manifests/github-sync-job.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: github-sync-
+  namespace: github-admin
+  labels:
+    app: github-sync
+    job: github-sync
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        job: github-sync
+        version: master
+    spec:
+      initContainers:
+      - name: checkout
+        command:
+        - /usr/local/bin/checkout_repos.sh
+        - --repos=kubeflow/internal-acls@HEAD
+        - --src_dir=/src
+        image: gcr.io/kubeflow-admin/test-worker:v20190723-0a32b01-dirty-b7e34b
+        volumeMounts:
+        - mountPath: /src
+          name: src
+      - name: validate
+        command:
+        - python
+        - /code/validate_config.py
+        - check-config
+        - /src/kubeflow/internal-acls/github-orgs/kubeflow/org.yaml
+        image: gcr.io/kubeflow-admin/test-worker:v20190723-0a32b01-dirty-b7e34b
+        volumeMounts:
+        - mountPath: /src
+          name: src
+        - mountPath: /code
+          name: validate-code
+      containers:
+      - name: sync
+        image: gcr.io/k8s-prow/peribolos@sha256:cb771295078f0a7353f375d39242ecafadcfc46650efb8a5f0adfa10b3f8c050
+        env:
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: github-org-admin-token
+              key: github_token
+        command:
+        - /app/prow/cmd/peribolos/app.binary.runfiles/io_k8s_test_infra/prow/cmd/peribolos/linux_amd64_pure_stripped/app.binary
+        - --fix-teams
+        - --fix-team-members
+        - --fix-org-members
+        - --fix-team-repos
+        - --config-path=/src/kubeflow/internal-acls/github-orgs/kubeflow/org.yaml
+        - --github-token-path=/secret/github-token/github_token
+        - --required-admins=jlewi
+        - --required-admins=james-jwu
+        - --required-admins=google-admin
+        - --required-admins=googlebot
+        - --confirm=true
+        volumeMounts:
+        - name: github-token
+          mountPath: /secret/github-token
+          readOnly: true
+        - mountPath: /src
+          name: src
+      restartPolicy: Never
+      volumes:
+      - name: github-token
+        secret:
+          secretName: github-org-admin-token
+      - name: src
+        emptyDir: {}
+      - name: validate-code
+        configMap:
+          name: github-sync-code

--- a/github-orgs/manifests/validate_config.py
+++ b/github-orgs/manifests/validate_config.py
@@ -1,0 +1,51 @@
+"""A python program to check the github org file.
+
+The purpose of this file is to guard against bad changes (e.g. adding someone)
+as an admin who shouldn't be an admin.
+"""
+import fire
+import logging
+import yaml
+
+class CheckConfig(object):
+  def check_config(seld, config):
+    """Check that the config is valid
+
+    Args:
+      config: Path to YAML file
+    """
+    with open(config) as hf:
+      org = yaml.load(hf)
+
+    admins = org.get("orgs").get("kubeflow").get("admins")
+
+    # There should be at least some admins
+    if not admins:
+      error = "config {0} is not valid; missing orgs.kubeflow.admins".format(
+        config)
+
+      logging.error(error)
+      raise ValueError(error)
+
+    # TODO(jlewi): We should load this in via config map
+    # Check that each admin is in a whitelist set of admins.
+    allowed_admins = ["Bobgy", "google-admin", "googlebot", "james-jwu", "jlewi",
+                      "k8s-ci-robot", "richardsliu", "rmgogogo", "theadactyl"]
+
+    for a in admins:
+      if not a in allowed_admins:
+        error = ("{0} is not in the allowed set of admins. "
+                 "Allowed admins is {1}").format(a, ", ".join(allowed_admins))
+        logging.error(error)
+        raise ValueError(error)
+
+    logging.info("config is valid")
+
+if __name__ == "__main__":
+  logging.basicConfig(level=logging.INFO,
+                    format=('%(levelname)s|%(asctime)s'
+                            '|%(message)s|%(pathname)s|%(lineno)d|'),
+                    datefmt='%Y-%m-%dT%H:%M:%S',
+                    )
+
+  fire.Fire(CheckConfig)


### PR DESCRIPTION
* This localizes the code in a single place which will make them
  easier to find and maintain going forward.

Fix #249