### PR TITLE
Add kfctl repo into third-party-bots

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -1013,6 +1013,7 @@ orgs:
             privacy: closed
             repos:
               katib: write
+              kfctl: write
           wg-automl-leads:
             description: Team for AutoML working group leads; permissions needed to create branches and other actions.
             maintainers:


### PR DESCRIPTION
Since we have a blocking sync issue as described #361 ,

Katib works fine, move foward with kfctl repo.

/cc @jlewi 