### PR TITLE
Add kfctl repo into third-party-bots

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -1013,6 +1013,7 @@ orgs:
             privacy: closed
             repos:
               katib: write
+              kfctl: write
               kfserving: write
           wg-automl-leads:
             description: Team for AutoML working group leads; permissions needed to create branches and other actions.


### PR DESCRIPTION
Since we have a blocking sync issue as described #361 ,

after we upgraded periobolos, moving back kfctl again to see if issue fixed.

/cc @jlewi 