### PR TITLE
Add the rest of repos into third-party-bots

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -1015,6 +1015,10 @@ orgs:
               katib: write
               kfctl: write
               kfserving: write
+              manifests: write
+              pytorch-operator: write
+              tf-operator: write
+              xgboost-operator: write
           wg-automl-leads:
             description: Team for AutoML working group leads; permissions needed to create branches and other actions.
             maintainers:


### PR DESCRIPTION
Since we have a blocking sync issue as described #361 ,

after we upgraded periobolos, kfctl has been added successfully, adding the rest of repos in one single PR

/cc @jlewi Let me know if you have any concerns