### PR TITLE
Remove temp admin access from PatrickXYS

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -998,14 +998,6 @@ orgs:
               tf-operator: write
               website: write
               xgboost-operator: write
-          temporary-admin-members:
-            description: Team for temporary admin access; Will be Removed at 01/20/2021
-            members:
-            - PatrickXYS
-            privacy: closed
-            repos:
-              katib: admin
-              pytorch-operator: admin
           third-party-bots-1321:
             description: Team for third party bots
             maintainers:


### PR DESCRIPTION
Since Katib + Pytorch has succeeded in migrating to Shared Test-infra, 

remove myself from temporary admin

/cc @Bobgy 