### PR TITLE
Adding Microsoft Azure Owners

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -194,6 +194,7 @@ orgs:
         - nicholas-abad
         - nickchase
         - NikeNano
+        - nilspohlmann
         - nqn
         - numerology
         - ohmystack
@@ -238,7 +239,8 @@ orgs:
         - saurabh24292
         - ScorpioCPH
         - scottilee
-        - shawnzhu
+        - shawnzhu 
+        - shbijlan
         - sijieamoy
         - songole
         - sperlingxx
@@ -261,11 +263,12 @@ orgs:
         - theofpa
         - thesuperzapper
         - tmckayus
-        - Tomcli
+        - Tomcli        
         - vditya
         - vishh
         - vkoukis
         - vpavlin
+        - vsetty-msft
         - wackxu
         - wbuchwalter
         - willb


### PR DESCRIPTION
Adding Microsoft Azure owners to the org to enable them as owners under Azure specific areas in other repositories under Kubeflow

@shbijlan  @nilspohlmann  @vsetty-msft

https://github.com/kubeflow/website/pull/2314