### PR TITLE
chore: move jlewi to member

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -10,7 +10,6 @@ orgs:
         - google-admin
         - googlebot
         - james-jwu
-        - jlewi
         - k8s-ci-robot
         billing_email: vishnukanan@gmail.com
         company: ""
@@ -142,6 +141,7 @@ orgs:
         - jinchihe
         - jingzhang36
         - jinxingwang
+        - jlewi
         - joeliedtke
         - johnugeorge
         - jose5918


### PR DESCRIPTION
https://github.com/kubeflow/internal-acls/pull/376 was partially reverted because of some issues in https://github.com/kubeflow/internal-acls/issues/384.

/assign @jlewi 