### PR TITLE
Add PatrickXYS as kubeflow-testing team member

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -868,6 +868,14 @@ orgs:
             privacy: closed
             repos:
               mxnet-operator: write
+          oncall-testing:
+            description: Team that will manage testing repo
+            maintainers:
+            - Bobgy
+            - PatrickXYS
+            privacy: closed
+            repos:
+              testing: write
           pipelines:
             description: Team responsible for kubeflow/pipelines project
             maintainers:


### PR DESCRIPTION
Given existing Shared Test-infra has some necessary work to be done, add myself as Kanban writer to help drive development of testing work.

Here are some data points I can come up with, which should be reviewed and finished after 1.2 release:

1. Migrate from ksonnet-based Argo Workflow to Tekton
2. To migrate to Tekton, we need to install / configure Tekton on Shared Test-infra
3. Provide uniform scripts and enforce WG to use scripts, sacrifice some flexibility to obtain better availability / management.
4. Research release infra, which is CD pipeline.
5. Divide test-infra into Production and Development environment, every change need to be tested on development env first, then deploy to production. This might slow down development speed, but I think it's necessary if WG want to use shared test-infra. Otherwise, they might need to find preferred solution. 
6. Automate Webhook Management https://github.com/kubeflow/internal-acls/issues/354
7. Existing kfctl + manifests are expensive and flaky, need to be more modular and stable
8. Generating Kubeflow + Kubernetes Compatibility Matrix
9. Expose Shared Test-infra configuration
10. Testing Image CD
11. Upgrade testing image dependencies https://github.com/kubeflow/testing/issues/779
12. Two bots screaming in the same PR if user calls `/retest`

/cc @jlewi @Jeffwan @Bobgy 