### PR TITLE
github-orgs: Add Arrikto team

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -240,7 +240,7 @@ orgs:
         - saurabh24292
         - ScorpioCPH
         - scottilee
-        - shawnzhu 
+        - shawnzhu
         - shbijlan
         - sijieamoy
         - songole
@@ -264,7 +264,7 @@ orgs:
         - theofpa
         - thesuperzapper
         - tmckayus
-        - Tomcli        
+        - Tomcli
         - vditya
         - vishh
         - vkoukis
@@ -562,6 +562,17 @@ orgs:
             - ohmystack
             - sperlingxx
             - zhujl1991
+            privacy: closed
+          Arrikto:
+            description: Team of members from Arrikto
+            maintainers:
+            - cvenets
+            - elikatsis
+            - jbottum
+            - kimwnasptd
+            - StefanoFioravanzo
+            - vkoukis
+            - yanniszark
             privacy: closed
           AWS:
             description: Team of members from AWS


### PR DESCRIPTION
Add Arrikto team to GitHub orgs so they can all be mentioned easily with
@kubeflow/arrikto.

/cc @Bobgy @jlewi 

BTW, I found this similar file in `kubeflow/community`: https://github.com/kubeflow/community/blob/master/member_organizations.yaml

Is it deprecated, or should I update that as well?

Signed-off-by: Yannis Zarkadas <yanniszark@arrikto.com>