### PR TITLE
Add mbaijal to Kubeflow org

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -180,6 +180,7 @@ orgs:
         - MartinForReal
         - mattf
         - Maximophone
+        - mbaijal
         - merlintang
         - mhausenblas
         - mitake


### PR DESCRIPTION
Addition to #243 for help with SageMaker and AWS components

Contributions:
- https://github.com/kubeflow/pipelines/pull/4536
- https://github.com/kubeflow/pipelines/pull/3830
- https://github.com/kubeflow/pipelines/pull/3771

Sponsors:
- RedbackThomson
- surajkota

I tried to run the `test_org_yaml.py` code, but you have a syntax error:
```
def test_team_member_is_in_org():
...
test_team_memeber_is_in_org()
```

Upon fixing that typo, it failed due to errors not related to my changes:
```
======================================================================= ERRORS =======================================================================
_________________________________________________________ ERROR collecting test_org_yaml.py __________________________________________________________
test_org_yaml.py:29: in <module>
    test_team_member_is_in_org()
test_org_yaml.py:25: in test_team_member_is_in_org
    assert team_member in org_members or team_member in org_admins, \
E   AssertionError: bobgy (team google-admins) not an admin or member of org kubeflow
E   assert ('bobgy' in ['8bitmp3', 'abcdefgs0324', 'abhi-g', 'abkosar', 'achalshant', 'adrian555', ...] or 'bobgy' in ['Bobgy', 'chensun', 'google-admin', 'googlebot', 'james-jwu', 'k8s-ci-robot'])
============================================================== short test summary info ===============================================================
ERROR test_org_yaml.py - AssertionError: bobgy (team google-admins) not an admin or member of org kubeflow
```