### PR TITLE
Add mbaijal to AWS org

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -581,10 +581,10 @@ orgs:
             - Jeffwan
             members:
             - akartsky
+            - mbaijal
             - PatrickXYS
             - RedbackThomson
             - surajkota
-            - mbaijal
             privacy: closed
           Azure:
             description: Contributors from Microsoft

--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -584,6 +584,7 @@ orgs:
             - PatrickXYS
             - RedbackThomson
             - surajkota
+            - mbaijal
             privacy: closed
           Azure:
             description: Contributors from Microsoft


### PR DESCRIPTION
Adds `mbaijal` to the `AWS` Kubeflow org.