### PR TITLE
Update wg-notebooks leads

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -1008,6 +1008,7 @@ orgs:
             - elikatsis
             - kimwnasptd
             - thesuperzapper
+            - yanniszark
             privacy: closed
           wg-pipeline-leads:
             description: Team for pipeline leads.


### PR DESCRIPTION
Add @yanniszark as a wg-notebooks lead. It seems this was missed. See the WG yaml file:
https://github.com/kubeflow/community/blob/master/wgs.yaml#L227-L256

/assign @Bobgy 

Signed-off-by: Yannis Zarkadas <yanniszark@arrikto.com>