### PR TITLE
wg-notebooks: Rename group to wg-notebooks-leads

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -999,7 +999,7 @@ orgs:
             privacy: closed
             repos:
               manifests: write
-          wg-notebook-leads:
+          wg-notebooks-leads:
             description: Team for Notebook working group leads.
             maintainers:
             - StefanoFioravanzo


### PR DESCRIPTION
The GitHub group for team leads of wg-notebooks was mistakenly named
`wg-notebook-leads`. Rename to `wg-notebooks-leads`, same as other wgs.

/cc @kubeflow/wg-notebook-leads 
/assign @Bobgy 

Signed-off-by: Yannis Zarkadas <yanniszark@arrikto.com>