### PR TITLE
Add kubeflow/kubeflow repo into third-party-bots

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -967,6 +967,7 @@ orgs:
               katib: write
               kfctl: write
               kfserving: write
+              kubeflow: write
               manifests: write
               pytorch-operator: write
               tf-operator: write


### PR DESCRIPTION
As part of https://github.com/kubeflow/kubeflow/issues/5482

We discussed with @kubeflow/wg-notebooks-leads in the issue, and agreed to add kubeflow/kubeflow repo write access to third-party-bots, by merging this PR, we'll be able to set up CI for kubeflow/kubeflow on Optional-Test-Infra.

/cc @Bobgy 
/cc @kubeflow/wg-notebooks-leads 