### PR TITLE
Add Jorge Castro and Rui Vasconselos as hosts and notetakers

### DIFF
--- a/google_groups/groups/community-meeting-hosts.yaml
+++ b/google_groups/groups/community-meeting-hosts.yaml
@@ -18,6 +18,10 @@ spec:
     role: MANAGER
   - email: thealamkin@google.com
     role: OWNER
+  - email: jorge.castro@arrikto.com
+    role: MEMBER
+  - email: rui.vasconcelos.mail@gmail.com   
+    role: MEMBER
   name: Community Meeting Hosts
   whoCanJoin: INVITED_CAN_JOIN
   whoCanPostMessage: ANYONE_CAN_POST


### PR DESCRIPTION
Rui and I would like the ability to notetake during the community meetings, much easier when we can edit so the host can concentrate on hosting.  