### PR TITLE
remove k8s-ci-bot from org

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -11,7 +11,6 @@ orgs:
         - googlebot
         - james-jwu
         - theadactyl
-        - k8s-ci-robot
         - google-oss-robot
         - zijianjoy
         billing_email: vishnukanan@gmail.com
@@ -769,7 +768,6 @@ orgs:
           ci-bots:
             description: Team for bots
             members:
-            - k8s-ci-robot
             - kubeflow-bot
             - google-oss-robot
             privacy: closed


### PR DESCRIPTION
k8s-ci-bot is no longer necessary after migration of test-infra to gcp oss prow in https://github.com/kubernetes/test-infra/issues/14343