### PR TITLE
Adding members to Azure Team

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -603,9 +603,11 @@ orgs:
           Azure:
             description: Contributors from Microsoft
             members:
+            - berndverst
             - dtzar
             - eedorenko
             - sudivate
+            - yilun-msft
             privacy: closed
           Caicloud:
             description: Team of members from Caicloud


### PR DESCRIPTION
Adding @yilun-msft and myself to the Azure team (we've been the most active contributors for Azure so it's unfortunate an unrelated Azure team didn't add us when they created the Azure group here)