### PR TITLE
Update release team in accordance with 

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -971,10 +971,9 @@ orgs:
             maintainers:
             - richardsliu
             members:
-            - Jeffwan
-            - swiftdiaries
-            - terrytangyuan
-            - yanniszark
+            - DavidSpek
+            - kimwnasptd
+            - RFMVasconcelos
             privacy: closed
             repos:
               arena: write


### PR DESCRIPTION
This PR updates the release team members to reflect the team chosen for the 1.4 release as per https://github.com/kubeflow/community/issues/517.

/cc @kimwnasptd @RFMVasconcelos @Bobgy

Also /cc @yanniszark, as you still might require these permissions for 1.3.1. If that is the case, we can merge this after the 1.3.1 release or include you up until that release.