### PR TITLE
Add Malini to release team

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -977,6 +977,7 @@ orgs:
             - DavidSpek
             - kimwnasptd
             - RFMVasconcelos
+            - mkbhanda
             privacy: closed
             repos:
               arena: write


### PR DESCRIPTION
As discussed in the Release Team meeting, Malini Bhandaruwill be joining the release team. This PR adds her to the release team.

/cc @Bobgy @mkbhanda @kubeflow/release-team 