### PR TITLE
Add wg102 to member list

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -300,6 +300,7 @@ orgs:
         - vsetty-msft
         - wackxu
         - wbuchwalter
+        - wg102
         - willb
         - willingc
         - woop


### PR DESCRIPTION
Hello!

Adding myself, wg102, to the kubeflow member list in order to be added to owner files. 
This is in relation to https://github.com/kubeflow/kubeflow/pull/6065 and following my work on https://github.com/kubeflow/kubeflow/pull/5880.

@kimwnasptd 

Thank you