### PR TITLE
Add Jose-Matsuda to member list

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -161,6 +161,7 @@ orgs:
         - joeliedtke
         - johnugeorge
         - jose5918
+        - Jose-Matsuda
         - jrykr
         - josiemundi
         - jtfogarty


### PR DESCRIPTION
Adding myself Jose-Matsuda to the member list so I may be added to owner files.
This is in relation to kubeflow/kubeflow#6065 and following my help on kubeflow/kubeflow#5880.

Same situation as https://github.com/kubeflow/internal-acls/pull/480


@kimwnasptd 

Thanks!