### PR TITLE
Fix the team visibility

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -732,6 +732,7 @@ orgs:
             description: Team at Nutanix contributing to Kubeflow.
             maintainers:
             - johnugeorge
+            privacy: closed
           Red Hat:
             description: Contributors from Red Hat
             members:


### PR DESCRIPTION
Updating the privacy field for Nutanix team as in given for other teams. Team visbility is shown as `secret` - https://github.com/orgs/kubeflow/teams