### PR TITLE
Adding Deepak to member list

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -88,6 +88,7 @@ orgs:
         - ddutta
         - ddysher
         - deadeyegoodwin
+        - deepak-muley
         - DeeperMind
         - DeliangFan
         - derekhh


### PR DESCRIPTION
Adding @deepak-muley to the Kubeflow member list

Deepak has contributed to training operator with multiple commits, reviews and issue reporting. Some of his contributions are 

https://github.com/kubeflow/tf-operator/pull/1375
https://github.com/kubeflow/tf-operator/pull/1368
https://github.com/kubeflow/tf-operator/pull/1346
https://github.com/kubeflow/tf-operator/pull/1349  
https://github.com/kubeflow/tf-operator/issues/1366

Thanks for all contributions to new training operator. 

/cc @zijianjoy @Bobgy 