### PR TITLE
Add Jaeyeon to member list

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -44,6 +44,7 @@ orgs:
         - amsaha
         - amygdala
         - andreyvelich
+        - anencore94
         - anfeng
         - animeshsingh
         - annajung


### PR DESCRIPTION
Adding @anencore94 to the Kubeflow member list. It helps us to assign issues, triggering CI/CD and update OWNERS files. 

Jaeyeon has contributed to Katib project with multiple commits and issues:

https://github.com/kubeflow/katib/pulls?q=author%3Aanencore94+
https://github.com/kubeflow/katib/issues?q=author%3Aanencore94+


Thank you for your help @anencore94!

/assign @kubeflow/wg-automl-leads @Bobgy @zijianjoy

/cc @anencore94