### PR TITLE
Remove outdated Ant Group team

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -590,14 +590,6 @@ orgs:
             description: Incubating project for xgboost operator
             has_projects: true
         teams:
-          Ant Group:
-            description: Team of members from Ant Group
-            maintainers:
-            - terrytangyuan
-            members:
-            - merlintang
-            - ohmystack
-            privacy: closed
           Arrikto:
             description: Team of members from Arrikto
             maintainers:


### PR DESCRIPTION
This team is no longer being maintained. Please refer to individual contributor's profile for the most update-to-date affiliation.