### PR TITLE
Add Yuki to member list

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -291,6 +291,7 @@ orgs:
         - Tabrizian
         - tasos-ale
         - tedhtchang
+        - tenzen-y
         - terrytangyuan
         - texasmichelle
         - thedriftofwords


### PR DESCRIPTION
Adding @tenzen-y to the Kubeflow member list. It helps us to assign issues, triggering CI/CD and update OWNERS files.

Yuki has contributed to Katib project with multiple commits and issues:

https://github.com/kubeflow/katib/pulls?q=author%3Atenzen-y+
https://github.com/kubeflow/katib/issues?q=author%3Atenzen-y+

Thank you for your help @tenzen-y!

/assign @kubeflow/wg-automl-leads @Bobgy @zijianjoy