### PR TITLE
Add FPGA OWNERS to member list

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -110,6 +110,7 @@ orgs:
         - edlee2121
         - eedorenko
         - eLco
+        - eliaskoromilas
         - elikatsis
         - ellistarn
         - elsonrodriguez
@@ -169,6 +170,7 @@ orgs:
         - Jose-Matsuda
         - jrykr
         - josiemundi
+        - jstamel
         - jtfogarty
         - judahrand
         - jzp1025


### PR DESCRIPTION
Adding @eliaskoromilas and @jstamel to the Kubeflow member list. It helps us to define OWNERS file under FPGA examples in Katib repository.
Ref PR: https://github.com/kubeflow/katib/pull/1685.

/assign @Bobgy @zijianjoy 

/cc @eliaskoromilas @jstamel @gaocegege @johnugeorge 

