### PR TITLE
Swap TF to Training operator

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -568,11 +568,11 @@ orgs:
             allow_squash_merge: false
             description: Test infrastructure and tooling for Kubeflow.
             has_projects: true
-          tf-operator:
+          training-operator:
             allow_merge_commit: false
             allow_rebase_merge: false
             allow_squash_merge: false
-            description: Tools for ML/Tensorflow on Kubernetes.
+            description: Training operators on Kubernetes.
             has_projects: true
           triage-issues:
             allow_merge_commit: false
@@ -834,7 +834,7 @@ orgs:
               pytorch-operator: write
               reporting: write
               testing: write
-              tf-operator: write
+              training-operator: write
               triage-issues: read
               website: write
               xgboost-operator: write
@@ -998,7 +998,7 @@ orgs:
               mpi-operator: write
               mxnet-operator: write
               pytorch-operator: write
-              tf-operator: write
+              training-operator: write
               website: write
               xgboost-operator: write
           third-party-bots-1321:
@@ -1014,7 +1014,7 @@ orgs:
               kubeflow: write
               manifests: write
               pytorch-operator: write
-              tf-operator: write
+              training-operator: write
               xgboost-operator: write
           wg-automl-leads:
             description: Team for AutoML working group leads; permissions needed to create branches and other actions.

--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -1088,7 +1088,7 @@ orgs:
             - terrytangyuan
             privacy: closed
             repos:
-              tf-operator: write
+              training-operator: write
               pytorch-operator: write
               mpi-operator: write
               xgboost-operator: write


### PR DESCRIPTION
After this PR: https://github.com/kubeflow/training-operator/issues/1348, we renamed `tf-operator` to `training-operator`.
We should make the appropriate changes.

/assign @kubeflow/wg-training-leads 

/cc @james-jwu @Bobgy @zijianjoy 