### PR TITLE
add jlbutler to member list

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -163,6 +163,7 @@ orgs:
         - jingzhang36
         - jinxingwang
         - ji-yaqi
+        - jlbutler
         - jlewi
         - joeliedtke
         - johnugeorge


### PR DESCRIPTION
I'd like to request Kubeflow org membership. Just one docs PR so far, but planning more. 

https://github.com/kubeflow/website/pull/2688

Sponsors:  @annajung @ellistarn 

I'm requesting ahead of additional contributions as the two listed approvers for the AWS distro are no longer working on the project, and we need to update with some current folks. Thanks!