### PR TITLE
Try to fix validate_config.py for Pyyaml breaking change

### DIFF
--- a/github-orgs/manifests/validate_config.py
+++ b/github-orgs/manifests/validate_config.py
@@ -15,7 +15,7 @@ class CheckConfig(object):
       config: Path to YAML file
     """
     with open(config) as hf:
-      org = yaml.load(hf)
+      org = yaml.load(hf, Loader=yaml.CLoader)
 
     admins = org.get("orgs").get("kubeflow").get("admins")
 


### PR DESCRIPTION
Error message:


+ python manifests/validate_config.py check_config kubeflow/org.yaml
Traceback (most recent call last):
  File "manifests/validate_config.py", line 52, in <module>
    fire.Fire(CheckConfig)
  File "/usr/local/lib/python3.7/site-packages/fire/core.py", line 141, in Fire
    component_trace = _Fire(component, args, parsed_flag_args, context, name)
  File "/usr/local/lib/python3.7/site-packages/fire/core.py", line 471, in _Fire
    target=component.__name__)
  File "/usr/local/lib/python3.7/site-packages/fire/core.py", line 681, in _CallAndUpdateTrace
    component = fn(*varargs, **kwargs)
  File "manifests/validate_config.py", line 18, in check_config
    org = yaml.load(hf)
TypeError: load() missing 1 required positional argument: 'Loader'


Usage:
https://github.com/yaml/pyyaml