### PR TITLE
Add myself to `ci-team`

### DIFF
--- a/google_groups/groups/ci-team.yaml
+++ b/google_groups/groups/ci-team.yaml
@@ -33,6 +33,8 @@ spec:
   # jlewi needs access for ACM management of label bot clusters
   - email: jeremy@lewi.us
     role: MEMBER
+  - email: judahrand@gmail.com
+    role: MEMBER
   - email: niklas.sven.hansson@gmail.com
     role: MEMBER
   - email: scottleehello@gmail.com

--- a/google_groups/groups/ci-viewer.yaml
+++ b/google_groups/groups/ci-viewer.yaml
@@ -34,8 +34,6 @@ spec:
     role: MEMBER
   - email: yliu989@bloomberg.net
     role: MEMBER
-  - email: judahrand@gmail.com
-    role: MEMBER
   name: ci-viewer
   whoCanJoin: CAN_REQUEST_TO_JOIN
   whoCanPostMessage: ALL_MEMBERS_CAN_POST


### PR DESCRIPTION
I'd thought that being a member of `ci-viewer` would be enough to debug https://github.com/kubeflow/pipelines/pull/6530 given some docs I found but it seems not. I still get 403. Perhaps if I'm in `ci-team` I'll be able to debug?