### PR TITLE
Add Seongjin to member list

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -276,6 +276,7 @@ orgs:
         - ScorpioCPH
         - scottilee
         - ScrapCodes
+        - seong7
         - shannonbradshaw
         - shawnzhu
         - shbijlan


### PR DESCRIPTION
Adding @seong7 to the Kubeflow member list. It helps us to assign issues, triggering CI/CD and update OWNERS files.

Seongjin has contributed to Katib project with multiple PRs and issues:

https://github.com/kubeflow/katib/pulls?q=author%3Aseong7
https://github.com/kubeflow/katib/issues?q=is%3Aissue+author%3Aseong7+

Thank you for your help @seong7!

/assign @kubeflow/wg-automl-leads @Bobgy @zijianjoy @anencore94