### PR TITLE
Add Vedant Padwal to member list

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -174,6 +174,7 @@ orgs:
         - jrykr
         - josiemundi
         - jstamel
+        - js-ts
         - jtfogarty
         - judahrand
         - jzp1025


### PR DESCRIPTION
I want to be a member of Kubeflow

I've mostly contributed to the [KServe Org](https://github.com/kserve/) ([BLOG](https://kserve.github.io/website/blog/articles/2021-10-11-KServe-0.7-release/), [DOCS, LOGO, WEBSITE](https://github.com/kserve/website/commits?author=js-ts))
https://github.com/search?q=org%3Akserve+type%3Apr+involves%3Ajs-ts

But I would like contribute to Kubeflow org as much as I can
For that I've taken the initiative to delete outdated examples ,update testing , add example links for Kubeflow documentation examples in the [examples repo](https://github.com/kubeflow/examples/)
https://groups.google.com/g/kubeflow-discuss/c/oh-0RRvpCr4
https://docs.google.com/document/d/1Wdxt1xedAj7qF_Rjmxy1R0NRdfv7UWs-r2PItewxHpE
https://docs.google.com/document/d/1cHAdK1FoGEbuQ-Rl6adBDL5W2YpDiUbnMLIwmoXBoAU
https://github.com/kubeflow/examples/issues/898 and have started to work on it
while asking @jinchihe about that , @jinchihe asked me if I would like to be maintainer/approver of [examples repo](https://github.com/kubeflow/examples/)
I replied yes as I'm very much interested in contributing and maintaining the [repo](https://github.com/kubeflow/examples/) , for that I made a PR https://github.com/kubeflow/examples/pull/899
https://github.com/apps/google-oss-prow commented that

> The following users are mentioned in OWNERS file(s) but are untrusted for the following reasons. One way to make the user trusted is to add them as members of the Kubeflow org. You can then trigger verification by writing /verify-owners in a comment.
> 
> - js-ts
>   - User is not a member of the org. User is not a collaborator. Satisfy at least one of these conditions to make the user trusted.
> 
> 

can you please approve this PR for that reason

PR's
https://github.com/kubeflow/examples/pull/899
https://github.com/kubeflow/blog/pull/107

ISSUES
https://github.com/kubeflow/examples/issues/898
https://github.com/kubeflow/kubeflow/issues/6140
https://github.com/kubeflow/website/issues/2951

and also I want to add support for dark mode and i18n support in the central dashboard and make a settings menu for it
I discussed that with @kimwnasptd liked the idea and would like to further discuss it with me
https://github.com/kubeflow/kubeflow/issues/6140
https://docs.google.com/document/d/1Wdxt1xedAj7qF_Rjmxy1R0NRdfv7UWs-r2PItewxHpE

Also I want to volunteer for the Kubeflow v1.5 release for KServe component and the models-web-app
https://docs.google.com/document/d/1KZUURwr9MnHXqHA08TFbfVbM8EAJSJjmaMhnvstvi-k

Kubeflow community has given me lot, I like the community very much , When I started looking for e2e recommender systems a while ago I couldn't find any open source projects for that
but then I found https://github.com/NVIDIA-Merlin/ which contained https://github.com/NVIDIA-Merlin/gcp-ml-ops which used Kubeflow in it , I wanted to know more about Kubeflow
In the beginning things were hard for me as I didn't find that many tutorials for it , https://www.coursera.org/learn/ml-pipelines-google-cloud was the best source as It had hands on labs thanks google for making the course it helped me a lot , I attended as many Kubeflow meetings I gained lot of new information from attending  , 
whatever projects I'm working has Kubeflow at its center , like End to End recommender system with Kubeflow, [NVIDIA-MERLIN](https://github.com/NVIDIA-Merlin/), [KServe](https://github.com/kserve/) and [The SAME-PROJECT](https://github.com/SAME-Project)
thanks to @yuzisun,@zijianjoy,@animeshsingh,@theofpa,@aronchick they helped me lot , I would use Kubeflow in many projects in the future and It would help me in my career, it's the best open source project with the best community

Sponsors @yuzisun, @jinchihe

/assign @zijianjoy @james-jwu
