### PR TITLE
Add my email in the google_groups/groups/example-maintainers.yaml file

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -174,6 +174,7 @@ orgs:
         - jrykr
         - josiemundi
         - jstamel
+        - js-ts
         - jtfogarty
         - judahrand
         - jzp1025

--- a/google_groups/groups/example-maintainers.yaml
+++ b/google_groups/groups/example-maintainers.yaml
@@ -12,6 +12,8 @@ spec:
     role: MEMBER
   - email: jinchihe@gmail.com
     role: MEMBER
+  - email: vedantpadwalinfi@gmail.com
+    role: MEMBER
   name: example-maintainers
   whoCanJoin: INVITED_CAN_JOIN
   whoCanPostMessage: ANYONE_CAN_POST


### PR DESCRIPTION
Adding My email to the [example-maintainers file](https://github.com/kubeflow/internal-acls/blob/master/google_groups/groups/example-maintainers.yaml)

I'm a maintainer of https://github.com/kubeflow/examples/
OWNER FILE: https://github.com/kubeflow/examples/blob/master/OWNERS