### PR TITLE
Remove inactive members of GitHub `web-team`

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -1089,11 +1089,7 @@ orgs:
               xgboost-operator: write
           web-team:
             description: Maintainers of `kubeflow/website`
-            maintainers:
-            - ewilderj
-            members:
-            - connor-mccarthy
-            - inc0
+            members: []
             privacy: closed
             repos:
               website: write

--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -1089,7 +1089,8 @@ orgs:
               xgboost-operator: write
           web-team:
             description: Maintainers of `kubeflow/website`
-            members: []
+            members:
+            - connor-mccarthy
             privacy: closed
             repos:
               website: write


### PR DESCRIPTION
This PR updates the members of the GitHub `web-team` (which has write access to the `kubeflow/website` repo) to remove people who are no longer working on the website, so no longer need this level of access.

__Removes:__
- @ewilderj
- ~@connor-mccarthy~ (re added, but still not sure if he needs it)
- @inc0