### PR TITLE
Add kubeflow repo permissions to GitHub `wg-notebooks-leads`

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -1044,6 +1044,8 @@ orgs:
             - thesuperzapper
             - yanniszark
             privacy: closed
+            repos:
+              kubeflow: write
           wg-pipeline-leads:
             description: Team for pipeline leads.
             maintainers:


### PR DESCRIPTION
Currently, all code that is controlled by the @kubeflow/wg-notebooks-leads lives inside the [kubeflow/kubeflow](https://github.com/kubeflow/kubeflow) repo:
- [`Admission Webhook (PodDefaults)`](https://github.com/kubeflow/kubeflow/tree/v1.4.0/components/admission-webhook)
- [`Central Dashboard`](https://github.com/kubeflow/kubeflow/tree/v1.4.0/components/centraldashboard)
- [`Jupyter Web App`](https://github.com/kubeflow/kubeflow/tree/v1.4.0/components/crud-web-apps/jupyter)
- [`Kubeflow Access Management API`](https://github.com/kubeflow/kubeflow/tree/v1.4.0/components/access-management)
- [`Notebook Controller`](https://github.com/kubeflow/kubeflow/tree/v1.4.0/components/notebook-controller)
- [`Profile Controller`](https://github.com/kubeflow/kubeflow/tree/v1.4.0/components/profile-controller)
- [`Tensorboard Controller`](https://github.com/kubeflow/kubeflow/tree/v1.4.0/components/notebook-controller)
- [`Tensorboard Web App`](https://github.com/kubeflow/kubeflow/tree/v1.4.0/components/crud-web-apps/volumes)
- [`Volumes Web App`](https://github.com/kubeflow/kubeflow/tree/v1.4.0/components/crud-web-apps/tensorboards)

I understand that the `kubeflow/kubeflow` repo is sensitive (it is the most "visible" kubeflow repo), but it has become very difficult for the @kubeflow/wg-notebooks-leads to take important actions on the repo, specifically:
- Managing Releases
- Managing Tags
- Managing Branches
- Managing Bot Configs

Without this change, only the [kubeflow org admins](https://github.com/kubeflow/internal-acls/blob/c09bfd1e980aae96675464bc8aaaf6bad24682a6/github-orgs/kubeflow/org.yaml#L7-L15) can take these actions on the `kubeflow/kubeflow` repo.