### PR TITLE
Create release-managers GitHub team

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -973,6 +973,15 @@ orgs:
             - Bobgy
             - paveldournov
             - theadactyl
+          release-managers:
+            description: Release team managers
+            members:
+              - kimwnasptd
+            privacy: closed
+            repos:
+              kubeflow: write
+              manifests: write
+              website: write
           release-team:
             description: Release team; permissions needed to create branches and other actions.
             maintainers:


### PR DESCRIPTION
Signed-off-by: Anna Jung (VMware) <antheaj@vmware.com>

Based on the discussion from https://github.com/kubeflow/internal-acls/pull/511 and Dec 13th release team meeting, the release team would like to create a separate GitHub team consisting of release manager, release docs lead, and release product manager that gives them write access to `kubeflow/kubeflow`, `kubeflow/manifests`, and `kubeflow/websites`.

- https://github.com/kubeflow/internal-acls/pull/511 removes write access to the existing "release-team" GitHub team while adding 1.5 members to it
