### PR TITLE
Create examples team

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -863,6 +863,14 @@ orgs:
             privacy: closed
             repos:
               code-intelligence: write
+          examples-team:
+            description: Team working on kubeflow/examples
+            members:
+            - jinchihe
+            - js-ts
+            privacy: closed
+            repos:
+              examples: write              
           github-actions:
             description: Team that will create new CI/CD with GitHub Actions
             maintainers:


### PR DESCRIPTION
Create examples team for the [approvers](https://github.com/kubeflow/examples/blob/master/OWNERS) of examples repo to get write access to the repo, to create branches and getting direct write access, instead of creating a PR everytime
members are @jinchihe @js-ts 