### PR TITLE
fix: use yaml.Loader instead of CLoader in validate_config.py

### DIFF
--- a/github-orgs/manifests/validate_config.py
+++ b/github-orgs/manifests/validate_config.py
@@ -15,7 +15,7 @@ class CheckConfig(object):
       config: Path to YAML file
     """
     with open(config) as hf:
-      org = yaml.load(hf, Loader=yaml.CLoader)
+      org = yaml.load(hf, Loader=yaml.Loader)
 
     admins = org.get("orgs").get("kubeflow").get("admins")
 


### PR DESCRIPTION
Due to https://github.com/yaml/pyyaml/issues/108, we cannot use CLoader any more.

Instead, I chose to use Loader as the reference in https://stackoverflow.com/questions/55677397/why-does-pyyaml-5-1-raise-yamlloadwarning-when-the-default-loader-has-been-made/56455769