### PR TITLE
add cjmccarthy to ci-team.yaml

### DIFF
--- a/google_groups/groups/ci-team.yaml
+++ b/google_groups/groups/ci-team.yaml
@@ -18,6 +18,8 @@ spec:
     role: MEMBER
   - email: chesu@google.com
     role: MEMBER
+  - email: cjmccarthy@google.com
+    role: MEMBER
   - email: dsun20@bloomberg.net
     role: MEMBER
   - email: gongyuan@google.com


### PR DESCRIPTION
Adds cjmccarthy@google.com to ci-team.yaml.﻿

Test output:
```
========================================= test session starts =========================================
platform darwin -- Python 3.10.2, pytest-7.0.1, pluggy-1.0.0
rootdir: /Users/cjmccarthy/workspace/internal-acls/github-orgs
collected 1 item                                                                                      

test_org_yaml.py .                                                                              [100%]

========================================== 1 passed in 0.10s ==========================================
```