### PR TITLE
Update release members and manager

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -925,7 +925,7 @@ orgs:
           release-managers:
             description: Kubeflow Release Team - Managers
             members:
-              - kimwnasptd
+              - annajung
             privacy: closed
             repos:
               kubeflow: write
@@ -934,15 +934,14 @@ orgs:
           release-team:
             description: Kubeflow Release Team
             members:
+            - akartsky
             - annajung
             - DomFleischmann
             - DnPlas
             - jbottum
             - js-ts
             - kimwnasptd
-            - shannonbradshaw
             - surajkota
-            - thesuperzapper
             privacy: closed
           third-party-bots-1321:
             description: Team for third party bots


### PR DESCRIPTION
Signed-off-by: Anna Jung (VMware) <antheaj@vmware.com>

Update the release team members based on [1.6 release team list](https://github.com/kubeflow/community/pull/560)

cc @kimwnasptd @kubeflow/release-team 