### PR TITLE
Add Chris Elliott to KFP org.

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -359,6 +359,7 @@ orgs:
         - zhujl1991
         - ziamsyed
         - zjj2wry
+        - zpChris
         - zw0610
         members_can_create_repositories: false
         name: Kubeflow
@@ -666,6 +667,7 @@ orgs:
             - zhenghuiwang
             - ziamsyed
             - zijianjoy
+            - zpChris
             privacy: closed
             repos:
               gcp-blueprints: write
@@ -913,6 +915,7 @@ orgs:
             - rui5i
             - sasha-gitg
             - zijianjoy
+            - zpChris
             privacy: closed
             repos:
               pipelines: write

--- a/google_groups/groups/ci-team.yaml
+++ b/google_groups/groups/ci-team.yaml
@@ -16,6 +16,8 @@ spec:
     role: MEMBER
   - email: avolkov@google.com
     role: MEMBER
+  - email: cell@google.com
+    role: MEMBER
   - email: chesu@google.com
     role: MEMBER
   - email: cjmccarthy@google.com


### PR DESCRIPTION
Add zpChris (cell@google.com) to the Kubeflow organization, Google team, and pipelines team, as well as to `ci-team.yaml` to administer Kubeflow CI infrastructure.

Test output from `pytest test_org_yaml.py` (included due to [these instructions](https://github.com/kubeflow/internal-acls#joining-kubeflow-github-organization)):
```
================================================================ test session starts ================================================================
platform linux -- Python 3.9.10, pytest-7.1.2, pluggy-1.0.0
rootdir: /usr/local/google/home/cell/Desktop/zpChris/internal-acls/github-orgs
collected 1 item                                                                                                                                    

test_org_yaml.py .                                                                                                                            [100%]

================================================================= 1 passed in 0.28s =================================================================
```