### PR TITLE
Update Release Team for 1.7

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -936,7 +936,7 @@ orgs:
           release-managers:
             description: Kubeflow Release Team - Managers
             members:
-              - annajung
+              - DomFleischmann
             privacy: closed
             repos:
               kubeflow: write
@@ -945,14 +945,18 @@ orgs:
           release-team:
             description: Kubeflow Release Team
             members:
-            - akartsky
+            - anencore94
             - annajung
+            - bradleykcardwell
+            - charlesa101
             - DomFleischmann
             - DnPlas
             - jbottum
-            - js-ts
             - kimwnasptd
+            - shivaylamba
             - surajkota
+            - Rishit-dagli
+            - yubozhao
             privacy: closed
           third-party-bots-1321:
             description: Team for third party bots

--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -957,16 +957,11 @@ orgs:
             members:
             - anencore94
             - annajung
-            - bradleykcardwell
-            - charlesa101
             - DomFleischmann
             - DnPlas
             - jbottum
             - kimwnasptd
-            - shivaylamba
             - surajkota
-            - Rishit-dagli
-            - yubozhao
             privacy: closed
           third-party-bots-1321:
             description: Team for third party bots


### PR DESCRIPTION
After the Release Team being officially formed (see [#kubeflow/community/issues/571](https://github.com/kubeflow/community/issues/571)). We need to update the acls with the new members and new roles.

Tagging all members in case I missed something:
@anencore94 @annajung @bradleykcardwell @chalesa101 @DnPlas @jbottum @kimwnasptd @shivaylamba @surajkota @Rishit-dagli @yubozhao