### PR TITLE
Add lehrig to the Member List

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -215,8 +215,8 @@ orgs:
         - kwasi
         - lalithvaka
         - LaynePeng
-        - lehrig
         - ldcastell
+        - lehrig
         - libbyandhelen
         - lienhua34
         - Linchin

--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -215,6 +215,7 @@ orgs:
         - kwasi
         - lalithvaka
         - LaynePeng
+        - lehrig
         - ldcastell
         - libbyandhelen
         - lienhua34


### PR DESCRIPTION
I'm mainly known for my work on this: https://github.com/kubeflow/kubeflow/issues/6684

On my private github (https://github.com/lehrig), you will find lots of related, open-sourced Kubeflow contributions, which my team will now upstream step-by-step to the Kubeflow community.