### PR TITLE
Remove gcp-blueprints as the repo was deleted. Part of #587

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -463,12 +463,6 @@ orgs:
             allow_squash_merge: false
             description: Repository for kubeflow frontend
             has_projects: true
-          gcp-blueprints:
-            allow_merge_commit: false
-            allow_rebase_merge: false
-            allow_squash_merge: false
-            description: Blueprints for Deploying Kubeflow on Google Cloud Platform and Anthos
-            has_projects: true
           internal-acls:
             allow_merge_commit: false
             allow_rebase_merge: false
@@ -686,8 +680,6 @@ orgs:
             - zijianjoy
             - zpChris
             privacy: closed
-            repos:
-              gcp-blueprints: write
           google-admins:
             description: Googlers to ping for help regarding Kubeflow's GitHub org and Google Groups
             members:
@@ -797,7 +789,6 @@ orgs:
               fairing: write
               fate-operator: write
               frontend: write
-              gcp-blueprints: write
               internal-acls: write
               katib: write
               kfctl: write


### PR DESCRIPTION
Part of #587

To solve the syncing error:
> {"component":"peribolos","file":"prow/cmd/peribolos/main.go:202","func":"main.main","level":"fatal","msg":"Configuration failed: failed to configure kubeflow team Google repos: failed to update team 2631639(Google) permissions on repo gcp-blueprints to write: status code 404 not one of [204], body: {"message":"Not Found","documentation_url":"[https://docs.github.com/rest/reference/teams#add-or-update-team-repository-permissions-legacy\"}","severity":"fatal","time":"2023-01-31T22:51:29Z"}](https://docs.github.com/rest/reference/teams#add-or-update-team-repository-permissions-legacy%5C%22%7D%22,%22severity%22:%22fatal%22,%22time%22:%222023-01-31T22:51:29Z%22%7D)
