### PR TITLE
fix broken sync

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -78,7 +78,6 @@ orgs:
         - chaselyall
         - chauhang
         - cheimu
-        - chensun
         - cheyang
         - chrisheecho
         - cjwagner


### PR DESCRIPTION
Sync was broken by #595, with error:

> Configuration failed: failed to configure kubeflow members: users in both roles: chensun

Turned out I can't be listed in admins and members at the same time. 