### PR TITLE
add rd-pong to member list

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -279,6 +279,7 @@ orgs:
         - ramdootp
         - randxie
         - raviranjan0309
+        - rd-pong
         - Realsen
         - rebeccamcfadden
         - RedbackThomson
@@ -599,6 +600,7 @@ orgs:
             - akartsky
             - ananth102
             - jsitu777
+            - rd-pong
             - RedbackThomson
             - ryansteakley
             - surajkota


### PR DESCRIPTION
My contributions:
Developed SageMaker Training Kubeflow Pipelines component v2 (TrainingJob). There is no PR under my user name due to internal processes.

Sponsors: @ananth102 @ryansteakley

Test results:

`
pytest test_org_yaml.py 
=========================================================================================== test session starts ===========================================================================================
platform darwin -- Python 3.10.10, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/rdpeng/Code/internal-acls/github-orgs
collected 1 item                                                                                                                                                                                          

test_org_yaml.py .                                                                                                                                                                                  [100%]

============================================================================================ 1 passed in 0.10s ============================================================================================
`
