### PR TITLE
[kubeflow 1.8] chore: update members of the Kubeflow 1.8 release team

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -955,6 +955,7 @@ orgs:
             - jbottum
             - juliusvonkohout
             - kimwnasptd
+            - nagar-ajay
             - NohaIhab
             - ryansteakley
             - surajkota

--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -951,6 +951,7 @@ orgs:
             - Davidnet
             - DomFleischmann
             - DnPlas
+            - helloericsf
             - jbottum
             - juliusvonkohout
             - kimwnasptd

--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -938,7 +938,7 @@ orgs:
           release-managers:
             description: Kubeflow Release Team - Managers
             members:
-              - DomFleischmann
+              - DnPlas
             privacy: closed
             repos:
               kubeflow: write
@@ -947,12 +947,14 @@ orgs:
           release-team:
             description: Kubeflow Release Team
             members:
-            - anencore94
             - annajung
+            - Davidnet
             - DomFleischmann
             - DnPlas
             - jbottum
+            - juliusvonkohout
             - kimwnasptd
+            - ryansteakley
             - surajkota
             privacy: closed
           third-party-bots-1321:

--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -955,6 +955,7 @@ orgs:
             - jbottum
             - juliusvonkohout
             - kimwnasptd
+            - NohaIhab
             - ryansteakley
             - surajkota
             privacy: closed


### PR DESCRIPTION
Adding the following members:
- @DnPlas as release manager
- @Davidnet, @juliusvonkohout, @ryansteakley, @nohaihab, @nagar-ajay  as members

Removing the following members:
- @anencore94

