### PR TITLE
add @mosabami to kubeflow org and azure team

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -614,7 +614,12 @@ orgs:
           Azure:
             description: Team of members from Azure
             members:
+            - berndverst
+            - dtzar
+            - eedorenko
             - mosabami
+            - sudivate
+            - yilun-msft
             privacy: closed
           Caicloud:
             description: Team of members from Caicloud

--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -244,6 +244,7 @@ orgs:
         - mitake
         - mkbhanda
         - moficodes
+        - mosabami
         - moxyoron
         - mpvartak
         - MrXinWang
@@ -613,11 +614,7 @@ orgs:
           Azure:
             description: Team of members from Azure
             members:
-            - berndverst
-            - dtzar
-            - eedorenko
-            - sudivate
-            - yilun-msft
+            - mosabami
             privacy: closed
           Caicloud:
             description: Team of members from Caicloud


### PR DESCRIPTION
I nominate @mosabami to be added to the Kubeflow org, as he is the current representative of Azure/Microsoft to the Kubeflow project.

Also, he can only be added to OWNERS files if he is a member, for example, I was unable to make him the owner of the Azure docs on the website: https://github.com/kubeflow/website/pull/3547

NOTE: I have also removed all the previous members of the @kubeflow/azure team, as they are no longer actively involved in the project.