### PR TITLE
add lowang-bh as member

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -230,6 +230,7 @@ orgs:
         - libbyandhelen
         - lienhua34
         - Linchin
+        - lowang-bh
         - lresende
         - luotigerlsx
         - lynnmatrix


### PR DESCRIPTION
```
github-orgs git:(lowang) ✗ pytest test_org_yaml.py
============================================================ test session starts ============================================================
platform darwin -- Python 3.10.11, pytest-7.3.1, pluggy-1.0.0
rootdir: /Users/wlh/go/src/github.com/kubeflow/internal-acls/github-orgs
plugins: anyio-3.6.2
collected 1 item

test_org_yaml.py .                                                                                                                    [100%]

============================================================= 1 passed in 0.08s =============================================================
➜  github-orgs git:(lowang)
```

Hi, members of Kubflow community. I am apply to be a member of training-operator and mpi-operator org.
Currently, I am a member of Volcano and I can help to maintain the volcano gang-schedule feature.
Here are my PRs:

## training-operator
[fix comment word spelling error #1826](https://github.com/kubeflow/training-operator/pull/1826)
[update volcano apis to v1.7.0 #1828](https://github.com/kubeflow/training-operator/pull/1828)
[support make test on darwin #1829](https://github.com/kubeflow/training-operator/pull/1829)
[e2e testing support volcano gang-scheduler #1831](https://github.com/kubeflow/training-operator/pull/1831)
[remove duplicate code of add task spec annotation #1839](https://github.com/kubeflow/training-operator/pull/1839)
[fetch volcano log when e2e failed #1837](https://github.com/kubeflow/training-operator/pull/1837)

## mpi-operator
[add volcano gang-scheduler pg min resource calculation #566](https://github.com/kubeflow/mpi-operator/pull/566)
[add volcano gang-schedule integration and e2e test #569](https://github.com/kubeflow/mpi-operator/pull/569)
[merge kubeflow/common.v1 to mpi-operator #571](https://github.com/kubeflow/mpi-operator/pull/571)

## In process

[update volcano scheduler to 1.8.0 #1894](https://github.com/kubeflow/training-operator/pull/1894)
[update full change list in changelog #1895](https://github.com/kubeflow/training-operator/pull/1895)
[update volcano scheduler to 1.8.0; ignore vendor #589](https://github.com/kubeflow/mpi-operator/pull/589)

