### PR TITLE
add write access to `kubeflow` repo for `wg-notebooks-leads`

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -1051,6 +1051,8 @@ orgs:
             - kimwnasptd
             - thesuperzapper
             privacy: closed
+            repos:
+              kubeflow: write
           wg-pipeline-leads:
             description: Team of Pipeline Working Group leads
             members:


### PR DESCRIPTION
Currently, none of the @kubeflow/wg-notebooks-leads have `write` access to the `kubeflow/kubeflow` repo.

I believe that @kimwnasptd and I are trusted enough to have the additional permissions, and we both agree not to make direct commits to the `master` branch of repo (which can be enforced with a branch-protection rule if the admins would like).

## Reason 1

This is causing significant problems because we are unable to approve GitHub action runs for new contributors (meaning our CI/CD never runs for these users).

GitHub introduced new security requirements for GitHub actions, and only members with `write` access can approve runs from PRs created by new contributors:

- https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks

## Reason 2

We cant manage our own GitHub actions jobs (e.g. canceling hung jobs and re-running them), as this requires write access to the repo.

## Reason 3

We cant create release tags for testing versions (or full releases).