### PR TITLE
Add caniszczyk and thelinuxfoundation as admins

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -5,12 +5,14 @@
 orgs:
     kubeflow:
         admins:
+        - caniszczyk
         - chensun
         - google-admin
         - google-oss-robot
         - googlebot
         - james-jwu
         - theadactyl
+        - thelinuxfoundation
         - zijianjoy
         billing_email: vishnukanan@gmail.com
         company: ""

--- a/github-orgs/manifests/validate_config.py
+++ b/github-orgs/manifests/validate_config.py
@@ -29,9 +29,9 @@ class CheckConfig(object):
 
     # TODO(jlewi): We should load this in via config map
     # Check that each admin is in a whitelist set of admins.
-    allowed_admins = ["chensun", "google-admin", "googlebot",
+    allowed_admins = ["caniszczyk", "chensun", "google-admin", "googlebot",
                       "google-oss-robot", "james-jwu", "jlewi", "k8s-ci-robot",
-                      "theadactyl", "zijianjoy"]
+                      "theadactyl", "thelinuxfoundation", "zijianjoy"]
 
     for a in admins:
       if not a in allowed_admins:


### PR DESCRIPTION
Part of https://github.com/cncf/toc/issues/1139

>  GitHub: ensure 'thelinuxfoundation' and 'caniszczyk' are added as initial org owners, this helps us make sure we have continuity of GH ownership that we will onboard to our GitHub Enterprise instance: https://github.com/enterprises/cncf

Add @caniszczyk and @thelinuxfoundation as admins to Kubeflow org.

cc @james-jwu @theadactyl @jbottum @zijianjoy 