### PR TITLE
adding vikas-saxena02 name to org.yaml

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -354,6 +354,7 @@ orgs:
         - Tomcli
         - toshi-k
         - vditya
+	- vikas-saxena02
         - vincent-pli
         - vishh
         - vkoukis

--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -354,7 +354,7 @@ orgs:
         - Tomcli
         - toshi-k
         - vditya
-	- vikas-saxena02
+        - vikas-saxena02
         - vincent-pli
         - vishh
         - vkoukis


### PR DESCRIPTION
I have been somewhat active in kubeflow community and have worked on following issues:

- https://github.com/kubeflow/website/issues/3536
-  https://github.com/kubeflow/pipelines/issues/9747

The PR for the first issue is https://github.com/kubeflow/website/pull/3597

I have also raised a few issues related to gaps that I identified with gaps in documentation. Example below:

- https://github.com/kubeflow/website/issues/3611


I am keen to work with @thesuperzapper on Notebooks 2.0 and also want to work on SparkOperatorIntegration in Kubeflow