### PR TITLE
fix: use batch/v1 for Cronjob.

### DIFF
--- a/github-orgs/manifests/github-sync-cron-job.yaml
+++ b/github-orgs/manifests/github-sync-cron-job.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: github-sync


### PR DESCRIPTION
Starting from k8s 1.21, batch/v1beta1 is not supporting Cronjob.

error: unable to recognize "github-sync-cron-job.yaml": no matches for kind "CronJob" in version "batch/v1beta1"