### PR TITLE
add tarilabs as member

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -346,6 +346,7 @@ orgs:
         - Swikar
         - Syulin7
         - Tabrizian
+        - tarilabs
         - tasos-ale
         - tedhtchang
         - tenzen-y


### PR DESCRIPTION
I have read the [guidelines for joining the Kubeflow GitHub org](https://www.kubeflow.org/docs/about/contributing/#joining-the-community).

Providing links to PRs or other contributions:

- contrib+doc mgt. for WG proposal https://github.com/kubeflow/community/pull/673
- doc mgt. for MR proposal https://github.com/kubeflow/community/pull/682
- size/XS https://github.com/kubeflow/website/pull/3659
- size/S https://github.com/kubeflow/website/pull/3660
- size/XS https://github.com/kubeflow/website/pull/3661
- size/XS https://github.com/kubeflow/examples/pull/1088
- size/XS https://github.com/kubeflow/examples/pull/1089
- website paragraph of logo history motivated: https://github.com/kubeflow/website/pull/3662
- Kaggle as pipeline example (submitted "4 hands" with another person) https://github.com/kubeflow/examples/pull/1091

Listing 2 existing members who are sponsoring the membership:

- @andreyvelich 
- @Tomcli 

Test your PR by running the following:
```
% cd github-orgs
pytest test_org_yaml.py
================================================= test session starts ==================================================
platform darwin -- Python 3.11.6, pytest-7.4.4, pluggy-1.3.0
rootdir: /Users/mmortari/git/kubeflow-internal-acls/github-orgs
collected 1 item                                                                                                       

test_org_yaml.py .                                                                                               [100%]

================================================== 1 passed in 0.09s ===================================================

```