### PR TITLE
Add Kubeflow Steering Committee team

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -962,12 +962,14 @@ orgs:
             privacy: closed
             repos:
               pipelines: write
-          project-steering-group:
-            description: Project Steering Group; Defined by Kubeflow governance
+          kubeflow-steering-committee:
+            description: Kubeflow Steering Committee; Defined by Kubeflow governance
             members:
+            - andreyvelich
             - james-jwu
-            - theadactyl
             - jbottum
+            - johnugeorge
+            - terrytangyuan
           release-managers:
             description: Kubeflow Release Team - Managers
             members:


### PR DESCRIPTION
This PR repurposes the existing `project-steering-group` team for Kubeflow Steering Committee and updates the list of members. 