### PR TITLE
add tarilabs to wg-model-registry-leads

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -1015,6 +1015,7 @@ orgs:
             members:
             - andreyvelich
             - ckadner
+            - tarilabs
             - Tomcli
             - rareddy
             privacy: closed


### PR DESCRIPTION
aligns to:
- https://github.com/kubeflow/model-registry/pull/4

see also:
https://github.com/kubeflow/model-registry/blob/158e5b9b88f4fc57a05f6f7c8cf5a83f88622de2/OWNERS#L4

thanks!