### PR TITLE
Update for manifests and notebooks WG leads

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -1039,23 +1039,16 @@ orgs:
           wg-manifests-leads:
             description: Team of Manifests Working Group Leads
             members:
-            - elikatsis
             - juliusvonkohout
             - kimwnasptd
-            - PatrickXYS
-            - StefanoFioravanzo
-            - yanniszark
             privacy: closed
             repos:
               manifests: write
           wg-notebooks-leads:
             description: Team of Notebooks Working Group leads
             members:
-            - elikatsis
             - kimwnasptd
-            - StefanoFioravanzo
             - thesuperzapper
-            - yanniszark
             privacy: closed
           wg-pipeline-leads:
             description: Team of Pipeline Working Group leads


### PR DESCRIPTION
Follow up chore of https://github.com/kubeflow/manifests/pull/2629 and https://github.com/kubeflow/kubeflow/pull/7402/
Were we already move some to emeritus_approvers. This PR propagates the change into the project-wide ACLs.

@james-jwu @zijianjoy for approval

@andreyvelich @johnugeorge @jbottum from KSC in CC