### PR TITLE
Add diegolovison as member to kubeflow org

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -110,6 +110,7 @@ orgs:
         - denkensk
         - derekhh
         - DharmitD
+        - diegolovison
         - difince
         - discordianfish
         - disktnk


### PR DESCRIPTION
**Provide 2-3 links to PRs or other contributions.**
Remove outdated versions of Kubernetes: https://github.com/kubeflow/manifests/pull/2640
Add steps to install Kubeflow on kind: https://github.com/kubeflow/manifests/pull/2634

**List 2 existing members who are sponsoring your membership.**
@hbelmiro @rimolive 

**Test your PR by running the following:**
```
$ pytest test_org_yaml.py
/home/dlovison/miniconda3/envs/ods-ci/lib/python3.11/site-packages/pytest_logger/plugin.py:104: PytestDeprecationWarning: The hookimpl LoggerPlugin.pytest_runtest_makereport uses old-style configuration options (marks or attributes).
Please use the pytest.hookimpl(hookwrapper=True) decorator instead
 to configure the hooks.
 See https://docs.pytest.org/en/latest/deprecations.html#configuring-hook-specs-impls-using-markers
  @pytest.mark.hookwrapper
========================================================================================================= test session starts ==========================================================================================================
platform linux -- Python 3.11.5, pytest-7.4.2, pluggy-1.3.0
rootdir: /home/dlovison/github/kubeflow/internal-acls/github-orgs
plugins: logger-0.5.1
collected 1 item                                                                                                                                                                                                                       

test_org_yaml.py .                                                                                                                                                                                                               [100%]

========================================================================================================== 1 passed in 0.06s ===========================================================================================================
```
