### PR TITLE
Update list of active IBM members

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -744,10 +744,10 @@ orgs:
           IBM:
             description: Team of members from IBM
             members:
-            - animeshsingh
             - ckadner
-            - fenglixa
-            - jinchihe
+            - JosepSampe
+            - revit13
+            - roytman
             - Tomcli
             - yhwang
             privacy: closed


### PR DESCRIPTION
Update list of IBM members that are still active in the past year.