### PR TITLE
Add distribution maintainers from VMware

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -244,6 +244,7 @@ orgs:
         - libbyandhelen
         - lienhua34
         - Linchin
+        - liuqi
         - lowang-bh
         - lresende
         - luotigerlsx
@@ -386,6 +387,7 @@ orgs:
         - xauthulei
         - xfate123
         - xieydd
+        - xujinheng
         - xychu
         - xyhuang
         - yanniszark


### PR DESCRIPTION
We are working on the Kubeflow distribution on VMware VCF and TKG. This PR is used to request to be the maintainers of this distribution. https://github.com/vmware/vSphere-machine-learning-extension

/cc @andreyvelich @xujinheng

Test results:

```
(kubeflow-acls) liuqi@Qis-MacBook-Pro github-orgs % pytest test_org_yaml.py
======================================================== test session starts ========================================================
platform darwin -- Python 3.10.13, pytest-8.1.1, pluggy-1.4.0
rootdir: /Users/liuqi/PycharmProjects/kubeflow-internal-acls/github-orgs
collected 1 item

test_org_yaml.py .                                                                                                            [100%]

========================================================= 1 passed in 0.96s =========================================================
```

Thank you.