### PR TITLE
Add rafalbigaj to kubeflow org

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -303,6 +303,7 @@ orgs:
         - QxiaoQ
         - r2d4
         - raddaoui
+        - rafalbigaj
         - rakelkar
         - ramdootp
         - randxie


### PR DESCRIPTION
I want to sponsor @rafalbigaj to the Kubeflow org because he has been contributing to pipelines and kfp-tekton for a while. He also have contributed to Tekton and Argo workflows as well.

Kubeflow PRs:
https://github.com/kubeflow/kfp-tekton/pull/963
https://github.com/kubeflow/pipelines/pull/4493