### PR TITLE
Add Data WG Team

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -1031,17 +1031,20 @@ orgs:
             privacy: closed
             repos:
               katib: write
-          wg-model-registry-leads:
-            description: Team of Model Registry
+          wg-data-leads:
+            description: Team of Data Working Group leads
             members:
             - andreyvelich
             - ckadner
             - tarilabs
             - Tomcli
             - rareddy
+            - vara-bonthu
+            - yuchaoran2011
             privacy: closed
             repos:
               model-registry: write
+              spark-operator: write
           wg-deployment-leads:
             description: Team of Deployment Working Group leads
             members:


### PR DESCRIPTION
Related: https://github.com/kubeflow/community/pull/673

I renamed WG Model Registry team to `wg-data-leads` and add write access to Model Registry and Spark Operator repos for WG Data members: @andreyvelich @ckadner @tarilabs @Tomcli @rareddy @vara-bonthu @yuchaoran2011

Please let me know if that sounds good to you.

/assign @kubeflow/kubeflow-steering-committee 
/hold for review