### PR TITLE
Add ederign as member

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -125,6 +125,7 @@ orgs:
         - dushyanthsc
         - dwhitena
         - dynamicwebpaige
+        - ederign
         - edlee2121
         - eedorenko
         - eLco

--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -778,8 +778,9 @@ orgs:
             description: Team of members from Red Hat
             members:
             - DharmitD
-            - erikerlandson
             - diegolovison
+            - ederign
+            - erikerlandson
             - gmfrasca
             - hbelmiro
             - HumairAK


### PR DESCRIPTION
This PR adds @ederign as a member.

He is a Red Hat employee that is assigned to Kubeflow.

He has been contributing significantly to the Notebooks 2.0 work (https://github.com/kubeflow/kubeflow/issues/7156), and we would like to add him as a reviewer in some sub-directory of the new [`kubeflow/notebooks`](https://github.com/kubeflow/notebooks) repo, so he needs to be a member of the org.

He is also a mentor for the GSOC Kubeflow Notebook 2.0 project.

Most of his contributions are currently non-code (designing UI for Noteoboks 2.0), but I expect this will change, here is is current first PR:
- https://github.com/kubeflow/notebooks/pull/4

