### PR TITLE
Add `jiridanek` as member and to Red Hat team

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -197,6 +197,7 @@ orgs:
         - jinchihe
         - jingzhang36
         - jinxingwang
+        - jiridanek
         - jiyongjung0
         - jlbutler
         - jlewi
@@ -789,6 +790,7 @@ orgs:
             - gregsheremeta
             - hbelmiro
             - HumairAK
+            - jiridanek
             - rareddy
             - rimolive
             - tarilabs


### PR DESCRIPTION
This PR adds @jiridanek as a member.

He is a Red Hat employee that is assigned to Kubeflow.

He has been contributing significantly to the Notebooks 2.0 work (https://github.com/kubeflow/kubeflow/issues/7156), and we would like to add him as a reviewer in some sub-directory of the new [kubeflow/notebooks](https://github.com/kubeflow/notebooks) repo, so he needs to be a member of the org.

Here are some PRs he has authored:

- https://github.com/kubeflow/notebooks/pull/5
- https://github.com/kubeflow/notebooks/pull/6
- https://github.com/kubeflow/notebooks/pull/10
- https://github.com/kubeflow/notebooks/pull/11