### PR TITLE
Add @ChenYi015 to the WG Data Leads

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -1057,6 +1057,7 @@ orgs:
             description: Team of Data Working Group leads
             members:
             - andreyvelich
+            - ChenYi015
             - ckadner
             - tarilabs
             - Tomcli


### PR DESCRIPTION
Adding @ChenYi015 to the WG Data leads.

@ChenYi015 has been contributing consistently to the Spark Operator project during last 4 months, and he will help with the Spark Operator releases.

Thank you for your great contributions @ChenYi015 🎉 

/hold for review

/assign @kubeflow/wg-data-leads @kubeflow/kubeflow-steering-committee  