### PR TITLE
chore: Attempt to remove google-admin from admin role of kubeflow org.

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -7,7 +7,6 @@ orgs:
         admins:
         - caniszczyk
         - chensun
-        - google-admin
         - google-oss-robot
         - googlebot
         - james-jwu
@@ -154,6 +153,7 @@ orgs:
         - Garrybest
         - gkcalat
         - gmfrasca
+        - google-admin
         - goswamig
         - greynutw
         - grobbie

--- a/github-orgs/manifests/github-sync-cron-job.yaml
+++ b/github-orgs/manifests/github-sync-cron-job.yaml
@@ -58,7 +58,6 @@ spec:
             - --config-path=/src/kubeflow/internal-acls/github-orgs/kubeflow/org.yaml
             - --github-token-path=/secret/github-token/github_token
             - --required-admins=james-jwu
-            - --required-admins=google-admin
             - --required-admins=googlebot
             - --confirm=true
             volumeMounts:

--- a/github-orgs/manifests/github-sync-job.yaml
+++ b/github-orgs/manifests/github-sync-job.yaml
@@ -54,7 +54,6 @@ spec:
         - --config-path=/src/kubeflow/internal-acls/github-orgs/kubeflow/org.yaml
         - --github-token-path=/secret/github-token/github_token
         - --required-admins=james-jwu
-        - --required-admins=google-admin
         - --required-admins=googlebot
         - --confirm=true
         volumeMounts:

--- a/github-orgs/manifests/validate_config.py
+++ b/github-orgs/manifests/validate_config.py
@@ -29,7 +29,7 @@ class CheckConfig(object):
 
     # TODO(jlewi): We should load this in via config map
     # Check that each admin is in a whitelist set of admins.
-    allowed_admins = ["caniszczyk", "chensun", "google-admin", "googlebot",
+    allowed_admins = ["caniszczyk", "chensun", "googlebot",
                       "google-oss-robot", "james-jwu", "jlewi", "k8s-ci-robot",
                       "theadactyl", "krook", "thelinuxfoundation", "zijianjoy"]
 

--- a/github-orgs/sync_org.sh
+++ b/github-orgs/sync_org.sh
@@ -70,7 +70,6 @@ elif [ "${action}" == "sync" ]; then
 		--fix-org-members ${FIX_ADMINS} --config-path ${DIR}/kubeflow/org.yaml \
 		--github-token-path ${token_file} \
 		--required-admins=james-jwu \
-		--required-admins=google-admin \
 		--required-admins=googlebot \
 		--confirm=${confirm}
     echo "Note: if dryrun=true you might get errors updating groups if the group doesn't exist"


### PR DESCRIPTION
Due to donation to CNCF, we can attempt to remove google-admin. However, look out for any unexpected issues with this change, and revert if needed.