### PR TITLE
fix: Deduplicate Kubeflow steering committee member in the member field

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -51,7 +51,6 @@ orgs:
         - amsaha
         - amygdala
         - ananth102
-        - andreyvelich
         - anencore94
         - anfeng
         - animeshsingh
@@ -194,7 +193,6 @@ orgs:
         - jagadeeshi2i
         - janeman98
         - jasonliu747
-        - jbottum
         - Jeffwan
         - jessesuen
         - jessiezcc
@@ -214,7 +212,6 @@ orgs:
         - JOCSTAA
         - joeliedtke
         - JohanWork
-        - johnugeorge
         - Jose-Matsuda
         - jose5918
         - JosepSampe
@@ -382,7 +379,6 @@ orgs:
         - tasos-ale
         - tedhtchang
         - tenzen-y
-        - terrytangyuan
         - texasmichelle
         - thedriftofwords
         - theofpa


### PR DESCRIPTION
because github doesn't allow role in both admins and members.