### PR TITLE
Request to add tonyxrmdavidson as a member of kubeflow.

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -386,6 +386,7 @@ orgs:
         - tmckayus
         - TobiasGoerke
         - Tomcli
+        - tonyxrmdavidson
         - toshi-k
         - vara-bonthu
         - vditya
@@ -812,6 +813,7 @@ orgs:
             - rimolive
             - tarilabs
             - terrytangyuan
+            - tonyxrmdavidson
             privacy: closed
           SUSE:
             description: Team of members from SUSE


### PR DESCRIPTION
Request to add tonyxrmdavidson, a member of Red Hat's model-registry team to the members list of kubeflow. 

### Output from 'pytest test_org_yaml.py'
`====================================================== test session starts =======================================================
platform darwin -- Python 3.9.19, pytest-8.3.3, pluggy-1.5.0
rootdir: /Users/tonydavidson/internal-acls/github-orgs
collected 1 item                                                                                                                 

test_org_yaml.py .                                                                                                         [100%]

======================================================= 1 passed in 0.11s ========================================================`

### Sponsoring members
Matteo Mortari - tarilabs
Ramesh Reddy - rareddy

### PR's Contributed
https://github.com/kubeflow/model-registry/pull/150
https://github.com/kubeflow/model-registry/pull/100 

