### PR TITLE
Add mvlassis as member of Kubeflow org

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -286,6 +286,7 @@ orgs:
         - mpvartak
         - MrXinWang
         - mukulikak
+        - mvlassis
         - mwielgus
         - nachocano
         - nagar-ajay


### PR DESCRIPTION
Closes #723 

Contributions:
- Part of the release team for 1.10
- Kubeflow 1.10 Liaison for the Notebooks WG


Output from `pytest test_org_yaml.py`:
```
============================================================ test session starts =============================================================
platform linux -- Python 3.12.7, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/manos/Github/internal-acls/github-orgs
plugins: anyio-4.4.0, typeguard-4.3.0
collected 1 item                                                                                                                             

test_org_yaml.py .                                                                                                                     [100%]

============================================================= 1 passed in 0.11s ==============================================================
```