### PR TITLE
Add @Griffin-Sullivan as Member of Kubeflow org

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -166,6 +166,7 @@ orgs:
         - goswamig
         - gregsheremeta
         - greynutw
+        - Griffin-Sullivan
         - grobbie
         - gsantomaggio
         - gsunner
@@ -812,6 +813,7 @@ orgs:
             - diegolovison
             - ederign
             - erikerlandson
+            - Griffin-Sullivan
             - gmfrasca
             - gregsheremeta
             - hbelmiro


### PR DESCRIPTION
# Membership Request

This PR adds @griffin-Sullivan as a member and closes https://github.com/kubeflow/internal-acls/issues/727.

He has contributed significantly to the Model Registry UI and Backend (BFF) work (https://github.com/kubeflow/model-registry/commits?author=Griffin-Sullivan) and is also to Notebooks 2.0.

**Please provide links to PRs or other contributions (2-3):**

- Model Registry contributions (~20 contributions): https://github.com/kubeflow/model-registry/commits?author=Griffin-Sullivan
- Contributions for Notebooks 2.0
https://github.com/kubeflow/notebooks/pull/67
https://github.com/kubeflow/notebooks/pull/73


**Please list 2 existing members who are sponsoring your membership:**

@ederign 
@tarilabs 

## Please test your PR

Run

```bash
cd github_orgs
pytest test_org_yaml.py
```

Include the output in the PR


```
====================================================================== test session starts ======================================================================
platform darwin -- Python 3.13.0, pytest-7.4.4, pluggy-1.0.0
rootdir: /Users/ederign/src/kubeflow/internal-acls/github-orgs
collected 1 item

test_org_yaml.py .                                                                                                                                        [100%]

======================================================================= 1 passed in 0.06s =======================================================================
```
## Additional Instructions

After your PR is merged please wait at least 1 hour for changes to propogate.

If after an hour you haven't recieved an invite to join the GitHub org please open an issue.
