### PR TITLE
Add @paulovmr as member

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -312,6 +312,7 @@ orgs:
         - ouadakarim
         - owlet42
         - PatrickXYS
+        - paulovmr
         - PaulinaPacyna
         - paveldournov
         - pdmack
@@ -828,6 +829,7 @@ orgs:
             - isinyaaa
             - jiridanek
             - lucferbux
+            - paulovmr
             - rareddy
             - rimolive
             - tarilabs


### PR DESCRIPTION
This PR adds @paulovmr as a member and to the @kubeflow/red-hat team.

He is a Red Hat employee that is assigned to Kubeflow.

He has been contributing significantly to the Notebooks 2.0 frontend work, for example he was the author of:

- https://github.com/kubeflow/notebooks/pull/140
- https://github.com/kubeflow/notebooks/pull/141
- https://github.com/kubeflow/notebooks/pull/174

He was the reviewer of:

- https://github.com/kubeflow/notebooks/pull/154
- https://github.com/kubeflow/notebooks/pull/160
- https://github.com/kubeflow/notebooks/pull/169