### PR TITLE
fix: improved membership request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/join_org.md
+++ b/.github/ISSUE_TEMPLATE/join_org.md
@@ -6,25 +6,29 @@ about: Request to join or modify Kubeflow GitHub membership
 
 # Membership Request
 
-Please read the [guidelines](https://www.kubeflow.org/docs/about/contributing/#joining-the-community) for joining the Kubeflow GitHub org before opening an issue
+## Instructions
+Please read the [guidelines](https://www.kubeflow.org/docs/about/contributing/#joining-the-community) for joining the Kubeflow GitHub org before opening an issue.
 
-**Please provide links to PRs or other contributions (2-3):**
+### Provide links to your PRs or other contributions (2-3):
 
-**Please list 2 existing members who are sponsoring your membership:**
+### List 2 existing members who are sponsoring your membership:
 
-## Please test your PR
-
-Run
-
-```bash
-cd github_orgs
-pytest test_org_yaml.py
-```
-
-Include the output in the PR
+### Create a new membership pull request (PR):
+- Fork the [kubeflow/internals-acls](https://github.com/kubeflow/internal-acls/) repo and clone it locally.
+- Modify [github-orgs/kubeflow/org.yaml](github-orgs/kubeflow/org.yaml) to include your GitHub username in the appropriate places.
+    - In the `org.kubeflow.members` list
+    - If you work for a company that is recognized by the Kubeflow project, then in your company team list (check `org.kubeflow.teams`)
+- Test your code changes with:
+    ```bash
+    cd github_orgs
+    pytest test_org_yaml.py
+    ```
+    Confirm that the test run passed, and make sure to copy the test output so you can include it in your PR description (on GitHub).
+- Push your changes to your `kubeflow/internals-acls` repository fork.
+- Open a PR from the [kubeflow/internals-acls](https://github.com/kubeflow/internal-acls/) repo.
+- Your PR will be reviewed by someone from the Kubeflow team. Work with your reviewers to address any outstanding issues.
 
 ## Additional Instructions
-
-After your PR is merged please wait at least 1 hour for changes to propogate.
-
-If after an hour you haven't recieved an invite to join the GitHub org please open an issue.
+- After your PR is merged please wait at least 1 hour for changes to propagate.
+- You will receive an email invite (to your GitHub associated email address) to join Kubeflow on GitHub. Follow the instructions on the email to accept your invitation.
+- If after an hour you haven't received an invite to join the GitHub org (or your invite has expired) please open an issue with an [owner](../../OWNERS) tagged to request follow-up.


### PR DESCRIPTION
This PR improves the instructions on the membership request template, fixing in particular the formatting and instructions on submitting a PR.

The issue was that the flow for becoming a Kubeflow member (as outlined [here](https://www.kubeflow.org/docs/about/membership/)) call for creating an issue. The issue template then mentions "Please test your PR". This is confusing because you haven't created a PR yet at this point.

In addition, there are no easily findable instructions stating that you need to "modify the `org.yaml` in the `github-orgs/kubeflow` directory. I had to search around the source code to find them when I was becoming a member.

This PR makes the process easier by formatting the membership request template, and by including more detailed instructions on what is required in the PR.