### PR TITLE
Updating OWNERS to emeritus_approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,3 +5,8 @@ approvers:
   - johnugeorge
   - terrytangyuan
   - zijianjoy
+
+emeritus_approvers:
+  - james-jwu
+  - jbottum
+


### PR DESCRIPTION
Moving previous KSC members to emeritus_approvers.

Follow up to https://github.com/kubeflow/internal-acls/pull/739 in https://github.com/kubeflow/community/issues/812