### PR TITLE
fix: Remove @haozheng95 from the Kubeflow GitHub org

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -178,7 +178,6 @@ orgs:
         - hackerboy01
         - hamelsmu
         - hansinikarunarathne
-        - haozheng95
         - hbelmiro
         - helenxie-bit
         - helloericsf


### PR DESCRIPTION
We should remove empty user from the list.

cc @kubeflow/kubeflow-steering-committee @zijianjoy @james-jwu @franciscojavierarceo @juliusvonkohout 