### PR TITLE
fix: Remove @prodonjs from the Kubeflow GitHub

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -755,7 +755,6 @@ orgs:
             - ouadakarim
             - PaulinaPacyna
             - pratyusharavi
-            - prodonjs
             - quanjielin
             - r2d4
             - Realsen


### PR DESCRIPTION
Related: https://github.com/kubeflow/internal-acls/issues/747

We are trying to see if this will fix the internal ACL sync.

cc @james-jwu 