### PR TITLE
Add @jenny-s51 as Member of Kubeflow org

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -202,6 +202,7 @@ orgs:
         - janeman98
         - jasonliu747
         - Jeffwan
+        - jenny-s51
         - jessesuen
         - jessiezcc
         - ji-yaqi
@@ -828,6 +829,7 @@ orgs:
             - hbelmiro
             - HumairAK
             - isinyaaa
+            - jenny-s51
             - jiridanek
             - lucferbux
             - paulovmr


### PR DESCRIPTION
This PR adds @jenny-s51  as a member and closes https://github.com/kubeflow/internal-acls/issues/749.

She has contributed significantly to the Model Registry UI work (https://github.com/kubeflow/model-registry/commits?author=jenny-s51) and is also to Notebooks 2.0.

### Provide links to your PRs or other contributions (2-3):

- Model Registry contributions (19): https://github.com/kubeflow/model-registry/commits?author=jenny-s51
- Contributions for Notebooks 2.0
https://github.com/kubeflow/notebooks/pull/183
https://github.com/kubeflow/notebooks/pull/185


### List 2 existing members who are sponsoring your membership:

@ederign
@lucferbux

## Please test your PR

Run

```bash
cd github_orgs
pytest test_org_yaml.py
```

Include the output in the PR


```
 github-orgs git:(add-jenny-as-member) pytest test_org_yaml.py   
=============================================================== test session starts ===============================================================
platform darwin -- Python 3.13.1, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/ederign/src/kubeflow/internal-acls/github-orgs
collected 1 item

test_org_yaml.py .                                                                                                                          [100%]

================================================================ 1 passed in 0.06s ================================================================
```
