### PR TITLE
Remove @franciscojavierarceo and @juliusvonkohout from org members

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -158,7 +158,6 @@ orgs:
         - fediazgon
         - fenglixa
         - fisherxu
-        - franciscojavierarceo
         - gabrielwen
         - gaocegege
         - gaoning777
@@ -232,7 +231,6 @@ orgs:
         - jstamel
         - jtfogarty
         - judahrand
-        - juliusvonkohout
         - junggil
         - jzp1025
         - kandrio


### PR DESCRIPTION
Ref: https://github.com/kubeflow/internal-acls/pull/704, https://github.com/kubeflow/community/issues/812

GitHub doesn't allow to be admin and member at the same time.