### PR TITLE
Add chasecadet as member

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -87,6 +87,7 @@ orgs:
         - ccarpentiere
         - ChanYiLin
         - chaselyall
+        - chasecadet
         - chauhang
         - cheimu
         - ChenYi015


### PR DESCRIPTION
PR to add Chase Christensen 
He has contributed significantly to outreach for the Kubeflow project. 
Provide links to your PRs or other contributions (2-3):

https://training.linuxfoundation.org/training/introduction-to-ai-ml-toolkits-with-kubeflow-lfs147/
https://www.youtube.com/watch?v=RlaAlszuSrA 


List 2 existing members who are sponsoring your membership:
@terrytangyuan 
@akgraner 


collected 1 item
test_org_yaml.py .                                                                                                                                                                                                                            [100%]
================================================================================================================= 1 passed in 0.06s =================================================================================================================
