### PR TITLE
Create GitHub Team for Kubeflow Trainer Maintainers

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -997,6 +997,15 @@ orgs:
             privacy: closed
             repos:
               kubebench: write
+          kubeflow-trainer-team:
+            description: Maintainers of `kubeflow/trainer`
+            members:
+            - andreyvelich
+            - Electronic-Waste
+            - johnugeorge
+            - terrytangyuan
+            - tenzen-y
+            privacy: closed
           mpi-operator-team:
             description: Maintainers of `kubeflow/mpi-operator`
             members:


### PR DESCRIPTION
This team should allow us to use /milestone label.

cc @Electronic-Waste @tenzen-y @johnugeorge @terrytangyuan 
