### PR TITLE
Add Crazyglue as kubeflow member

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -102,6 +102,7 @@ orgs:
         - codeflitting
         - connor-mccarthy
         - ConnorDoyle
+        - Crazyglue
         - crobby
         - cspavlou
         - cvenets
@@ -828,6 +829,7 @@ orgs:
             - alexcreasy
             - anishasthana
             - astefanutti
+            - Crazyglue
             - dandawg
             - DharmitD
             - diegolovison


### PR DESCRIPTION
Related issue: https://github.com/kubeflow/internal-acls/issues/768

Sponsors:

@rareddy 
@tarilabs 

Pytest results:

```
➜  github-orgs git:(crazyglue-member-addition) pytest test_org_yaml.py
=================================================================== test session starts ====================================================================
platform darwin -- Python 3.12.9, pytest-8.3.5, pluggy-1.5.0
rootdir: /Users/edobrove/code/internal-acls/github-orgs
collected 1 item                                                                                                                                           

test_org_yaml.py .                                                                                                                                   [100%]

==================================================================== 1 passed in 0.06s =====================================================================

```