### PR TITLE
Add @christianvogt as Member of Kubeflow org

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -103,6 +103,7 @@ orgs:
         - connor-mccarthy
         - ConnorDoyle
         - Crazyglue
+        - christianvogt
         - crobby
         - cspavlou
         - cvenets
@@ -831,6 +832,7 @@ orgs:
             - anishasthana
             - astefanutti
             - Crazyglue
+            - christianvogt
             - dandawg
             - DharmitD
             - diegolovison


### PR DESCRIPTION
# Membership Request

This issue adds @christianvogt as a member.

He has continuously contributed to the Model Registry UI and BFF, with highlights to his work on support for module federation on the Model Registry UI and multiple PR reviews.

Please provide links to PRs or other contributions (2-3):
- https://github.com/kubeflow/model-registry/pull/798
- https://github.com/kubeflow/model-registry/pull/832
- https://github.com/kubeflow/model-registry/pull/895
- https://github.com/kubeflow/model-registry/pull/898
- https://github.com/kubeflow/model-registry/pull/913

### List 2 existing members who are sponsoring your membership:
@ederign @jenny-s51 @lucferbux 

### Testing this PR:

```python
============================= test session starts ==============================
platform darwin -- Python 3.12.4, pytest-7.4.4, pluggy-1.0.0
rootdir: /Users/ederign/src/kubeflow/internal-acls/github-orgs
plugins: anyio-4.2.0
collected 1 item

test_org_yaml.py .                                                       [100%]

============================== 1 passed in 0.06s ===============================

```