### PR TITLE
update release manager 1.11

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -1096,7 +1096,7 @@ orgs:
           release-managers:
             description: Kubeflow Release Team - Managers
             members:
-              - rimolive
+              - varodrig
             privacy: closed
             repos:
               kubeflow: write
@@ -1111,6 +1111,7 @@ orgs:
             - thesuperzapper
             - ca-scribner
             - juliusvonkohout
+            - varodrig
             privacy: closed
           third-party-bots-1321:
             description: Team for third party bots


### PR DESCRIPTION
Update Kubeflow Release Manager 1.11

<img width="1654" alt="image" src="https://github.com/user-attachments/assets/51c4dfc2-da02-4c2f-b8b3-7d92267726e5" />

New Release Manager for 1.11
cc @rimolive @juliusvonkohout 
please review/approve @andreyvelich @franciscojavierarceo 