### PR TITLE
Adding @caponetto as a member

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -83,6 +83,7 @@ orgs:
         - Bobgy
         - c-bata
         - ca-scribner
+        - caponetto
         - capri-xiyue
         - CarterFendley
         - carmark
@@ -840,6 +841,7 @@ orgs:
             - alexcreasy
             - anishasthana
             - astefanutti
+            - caponetto
             - Crazyglue
             - christianvogt
             - dandawg


### PR DESCRIPTION
Closes https://github.com/kubeflow/internal-acls/issues/786

This PR adds @caponetto as a member and to the @kubeflow/red-hat team.

He is a Red Hat employee that is assigned to Kubeflow, and has been making valuable contributions to the Notebooks 2.0 frontend work, for example he was the author of:

https://github.com/kubeflow/notebooks/pull/314
https://github.com/kubeflow/notebooks/pull/346
https://github.com/kubeflow/notebooks/pull/370

Test results:

```
============================================================================================================================================================= test session starts ==============================================================================================================================================================
platform linux -- Python 3.12.3, pytest-7.4.4, pluggy-1.4.0
rootdir: /opt/home/paulo/projects/redhat/forks/internal-acls/github-orgs
collected 1 item                                                                                                                                                                                                                                                                                                                               

test_org_yaml.py .                                                                                                                                                                                                                                                                                                                       [100%]

============================================================================================================================================================== 1 passed in 0.05s ===============================================================================================================================================================
```