### PR TITLE
Adding @thaorell as a member

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -407,6 +407,7 @@ orgs:
         - tedhtchang
         - tenzen-y
         - texasmichelle
+        - thaorell
         - thedriftofwords
         - theofpa
         - thesuperzapper
@@ -865,6 +866,7 @@ orgs:
             - syntaxsdev
             - tarilabs
             - terrytangyuan
+            - thaorell
             - YosiElias
             privacy: closed
           SUSE:


### PR DESCRIPTION
Closes https://github.com/kubeflow/internal-acls/issues/788

This PR adds @thaorell as a member and to the @kubeflow/red-hat team.

He is a Red Hat employee that is assigned to Kubeflow, and has been making valuable contributions to the Notebooks 2.0 frontend work, for example he was the author of:

https://github.com/kubeflow/notebooks/pull/326
https://github.com/kubeflow/notebooks/pull/315
https://github.com/kubeflow/notebooks/pull/310
https://github.com/kubeflow/notebooks/pull/303

Test results:

```
============================================================================================================================================================= test session starts ==============================================================================================================================================================
platform linux -- Python 3.12.3, pytest-7.4.4, pluggy-1.4.0
rootdir: /opt/home/paulo/projects/redhat/forks/internal-acls/github-orgs
collected 1 item                                                                                                                                                                                                                                                                                                                               

test_org_yaml.py .                                                                                                                                                                                                                                                                                                                       [100%]

============================================================================================================================================================== 1 passed in 0.05s ===============================================================================================================================================================
```