### PR TITLE
Add @andyatmiami as Member of Kubeflow org

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -56,6 +56,7 @@ orgs:
         - amsaha
         - amygdala
         - ananth102
+        - andyatmiami
         - anencore94
         - anfeng
         - animeshsingh
@@ -843,6 +844,7 @@ orgs:
             - adysenrothman
             - Al-Pragliola
             - alexcreasy
+            - andyatmiami
             - anishasthana
             - astefanutti
             - caponetto


### PR DESCRIPTION
This issue adds @andyatmiami as a member and closes https://github.com/kubeflow/internal-acls/issues/791 . He has continuously contributed to the Notebooks 2.0 and Dashboard migration.


### Provide links to your PRs or other contributions (2-3):
- https://github.com/kubeflow/notebooks/pull/331
- https://github.com/kubeflow/dashboard/pull/84
- https://github.com/kubeflow/dashboard/pull/92
- https://github.com/kubeflow/dashboard/pull/96

### List 2 existing members who are sponsoring your membership:
@ederign  @paulovmr 

### Testing this PR:
============================= test session starts ==============================
platform darwin -- Python 3.12.4, pytest-7.4.4, pluggy-1.0.0
rootdir: /Users/ederign/src/kubeflow/internal-acls/github-orgs
plugins: anyio-4.2.0
collected 1 item

test_org_yaml.py .                                                       [100%]

============================== 1 passed in 0.06s ===============================
