### PR TITLE
add Al-Pragliola to model-registry Maintainers

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -1151,6 +1151,7 @@ orgs:
           wg-data-leads:
             description: Team of Data Working Group leads
             members:
+            - Al-Pragliola
             - andreyvelich
             - ChenYi015
             - ckadner


### PR DESCRIPTION
- Alessio made it to Reviewer on Feb 26th, 2025 with https://github.com/kubeflow/model-registry/pull/836
- Alessio made it to Approver on May 26th, 2025 with https://github.com/kubeflow/model-registry/pull/1153
- to support with Model Registry release process: https://github.com/kubeflow/model-registry/blob/main/RELEASE.md#instructions we need him to be included into the github repo Maintainers:

https://github.com/kubeflow/internal-acls/blob/2e8ac10bc434d45dad876a93963679b60f726541/github-orgs/kubeflow/org.yaml#L1163-L1164

This PR reflect this to support accordingly.