### PR TITLE
REQUEST: Add @rudeigerc as Member

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -369,6 +369,7 @@ orgs:
         - rongou
         - roytman
         - rpasricha
+        - rudeigerc
         - rui5i
         - Ruminateer
         - ryandawsonuk


### PR DESCRIPTION
@rudeigerc has contributed a lot to kubeflow/trainer, including several PRs:

- https://github.com/kubeflow/trainer/pull/2731
- https://github.com/kubeflow/trainer/pull/2719
- https://github.com/kubeflow/trainer/pull/2728
- https://github.com/kubeflow/trainer/pull/2732
- https://github.com/kubeflow/trainer/pull/2734

And he also helped a lot in mentoring @Doris-xm with her GSoC project(https://github.com/kubeflow/trainer/issues/2671), including KEP reviews and attending every weekly sync meeting.

I'm glad to nominate @rudeigerc as member of Kubeflow. He is well qualified for this!

Looking forward to collaborating with you in the future! And wish to see more contributions.

/cc @andreyvelich @tenzen-y @astefanutti @rudeigerc @Doris-xm 

Test Results:

```sh
============================================================================ test session starts ============================================================================
platform linux -- Python 3.11.9, pytest-8.3.2, pluggy-1.5.0
rootdir: /home/ws/kubeflow/internal-acls/github-orgs
collected 1 item                                                                                                                                                            

test_org_yaml.py .                                                                                                                                                    [100%]

============================================================================= 1 passed in 0.15s =============================================================================
```

