### PR TITLE
chore: Add `docs-agent` repository

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -550,6 +550,12 @@ orgs:
             allow_squash_merge: false
             description: Kubeflow Central Dashboard is the web interface for Kubeflow
             has_projects: true
+          docs-agent:
+            allow_merge_commit: false
+            allow_rebase_merge: false
+            allow_squash_merge: false
+            description: Kubeflow Documentation AI Agent to power the Kubeflow Website
+            has_projects: true
           example-seldon:
             allow_merge_commit: false
             allow_rebase_merge: false
@@ -676,12 +682,6 @@ orgs:
             allow_rebase_merge: false
             allow_squash_merge: false
             description: Kubeflow SDK for ML Experience
-            has_projects: true
-          docs-agent:
-            allow_merge_commit: false
-            allow_rebase_merge: false
-            allow_squash_merge: false
-            description: Kubeflow Documentation AI Agent to power the Kubeflow Website
             has_projects: true
           testing:
             allow_merge_commit: false

--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -677,6 +677,12 @@ orgs:
             allow_squash_merge: false
             description: Kubeflow SDK for ML Experience
             has_projects: true
+          docs-agent:
+            allow_merge_commit: false
+            allow_rebase_merge: false
+            allow_squash_merge: false
+            description: Kubeflow Documentation AI Agent to power the Kubeflow Website
+            has_projects: true
           testing:
             allow_merge_commit: false
             allow_rebase_merge: false


### PR DESCRIPTION
Add the Kubeflow Docs Agent repository for https://github.com/kubeflow/website/issues/4025. 

For now, I will grant the mentors and Santhosh write access, but in the future we can discuss the access.

/cc @kubeflow/kubeflow-steering-committee @SanthoshToorpu @chasecadet @varodrig 