### PR TITLE
Add GSoC contributors to Kubeflow members list

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -40,6 +40,7 @@ orgs:
         - ahousley
         - ajchili
         - Akado2009
+        - akagami-harsh
         - akartsky
         - akgraner
         - akshaychitneni
@@ -271,6 +272,7 @@ orgs:
         - krzyzacy
         - kubeflow-bot
         - kuizhiqing
+        - kunal-511
         - kunmingg
         - kwasi
         - lalithvaka
@@ -285,12 +287,14 @@ orgs:
         - Linchin
         - liuqi
         - lowang-bh
+        - LogicalGuy77
         - lresende
         - lucferbux
         - lugi0
         - luotigerlsx
         - lynnmatrix
         - MaanavD
+        - madmecodes
         - mahdikhashan
         - mameshini
         - marcoceppi


### PR DESCRIPTION
### Contribution Links

- [#3070](https://github.com/kubeflow/manifests/pull/3070)
- [#3077](https://github.com/kubeflow/manifests/pull/3077)

### Sponsors (2 current members)

- @juliusvonkohout 
- @varodrig 

cc: @madmecodes @akagami-harsh @LogicalGuy77