### PR TITLE
Add Kubeflow SDK Contributors to Kubeflow GitHub Org

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -80,6 +80,7 @@ orgs:
         - bikramnehra
         - biswajit-9776
         - bmorphism
+        - briangallagher
         - Bobgy
         - c-bata
         - ca-scribner
@@ -153,6 +154,7 @@ orgs:
         - ellistarn
         - elsonrodriguez
         - elviraux
+        - eoinfennessy
         - erikerlandson
         - eterna2
         - evan-hataishi
@@ -396,6 +398,7 @@ orgs:
         - Swikar
         - syntaxsdev
         - Syulin7
+        - szaher
         - Tabrizian
         - tarekabouzeid
         - tarilabs


### PR DESCRIPTION
I would like to add Kubeflow SDK members to the Kubeflow GitHub org, given their contributions and help with Kubeflow SDK:

- @briangallagher: https://github.com/kubeflow/sdk/commits?author=briangallagher
- @eoinfennessy: https://github.com/kubeflow/sdk/commits?author=eoinfennessy
- @szaher: https://github.com/kubeflow/sdk/commits?author=szaher

Thanks for all of your great contributions 🎉 

/assign @kubeflow/kubeflow-steering-committee 