### PR TITLE
tenzen-y steps down from AutoML ownership role

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -876,7 +876,6 @@ orgs:
             - andreyvelich
             - gaocegege
             - johnugeorge
-            - tenzen-y
             privacy: closed
             repos:
               katib: write


### PR DESCRIPTION
REF: https://github.com/kubeflow/katib/pull/2561
