### PR TITLE
Add pschoen-itsc to members

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -349,6 +349,7 @@ orgs:
         - pineking
         - pingsutw
         - pratyusharavi
+        - pschoen-itsc
         - pugangxa
         - puneith
         - pvaneck


### PR DESCRIPTION
Added seaweedfs basis for minio replacement in Kubeflow Pipelines. Need to be member to be in OWNER file for that https://github.com/kubeflow/pipelines/pull/11965/files#diff-b5e4615d141dcf410cf2efd9c7e9d95940a64f61599072b1962049dacafa0671

Original contributions:
- kubeflow/manifests#2826
- kubeflow/manifests#3051