### PR TITLE
Remove more Kubeflow GitHub teams

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -774,15 +774,6 @@ orgs:
             - yuzisun
             - yuzliu
             privacy: closed
-          kube-bench-team:
-            description: Maintainers of `kubeflow/kubebench`
-            members:
-            - gaocegege
-            - jlewi
-            - xyhuang
-            privacy: closed
-            repos:
-              kubebench: write
           kubeflow-trainer-team:
             description: Maintainers of `kubeflow/trainer`
             members:
@@ -805,24 +796,6 @@ orgs:
             privacy: closed
             repos:
               mpi-operator: write
-          mxnet-operator-team:
-            description: Maintainers of `kubeflow/mxnet-operator`
-            members:
-            - Jeffwan
-            - suleisl2000
-            - terrytangyuan
-            - wackxu
-            privacy: closed
-            repos:
-              mxnet-operator: write
-          oncall-testing:
-            description: Maintainers of `kubeflow/testing`
-            members:
-            - PatrickXYS
-            - zijianjoy
-            privacy: closed
-            repos:
-              testing: write
           kubeflow-outreach-committee:
             description: Kubeflow Outreach Committee
             members:
@@ -858,20 +831,6 @@ orgs:
             - juliusvonkohout
             - varodrig
             privacy: closed
-          third-party-bots-1321:
-            description: Team for third party bots
-            members:
-            - aws-kf-ci-bot
-            privacy: closed
-            repos:
-              katib: write
-              kfctl: write
-              kfp-tekton: write
-              kubeflow: write
-              manifests: write
-              pytorch-operator: write
-              trainer: write
-              xgboost-operator: write
           wg-automl-leads:
             description: Team of AutoML Working Group leads
             members:
@@ -959,21 +918,4 @@ orgs:
               pytorch-operator: write
               sdk: write
               trainer: write
-              xgboost-operator: write
-          web-team:
-            description: Maintainers of `kubeflow/website`
-            members:
-            - connor-mccarthy
-            privacy: closed
-            repos:
-              website: write
-          xgboost-operator-team:
-            description: Maintainers of `kubeflow/xgboost-operator`
-            members:
-            - johnugeorge
-            - merlintang
-            - richardsliu
-            - terrytangyuan
-            privacy: closed
-            repos:
               xgboost-operator: write


### PR DESCRIPTION
Followup for: https://github.com/kubeflow/internal-acls/pull/816
I deleted more teams as part of this PR.

/assign @anishasthana @kubeflow/kubeflow-steering-committee