### PR TITLE
Add kannon92 as a member

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -253,6 +253,7 @@ orgs:
         - junggil
         - jzp1025
         - kandrio
+        - kannon92
         - karlschriek
         - karthikv2k
         - katieole


### PR DESCRIPTION
I would like to nominate @kannon92 as Kubeflow GitHub org member.

Kevin was helping us with Kubeflow Trainer v2 design and development, and made several contributions to Kubeflow Trainer:
- https://github.com/kubeflow/trainer/issues?q=author%3Akannon92
- DevStats: https://kubeflow.devstats.cncf.io/d/66/developer-activity-counts-by-companies?orgId=1&var-period_name=Last%202%20years&var-metric=contributions&var-repogroup_name=All&var-country_name=All&var-companies=All

/assign @kubeflow/kubeflow-trainer-team @kubeflow/kubeflow-steering-committee 