### PR TITLE
Add myself and Andrey as calendar admins

### DIFF
--- a/google_groups/groups/calendar-admins.yaml
+++ b/google_groups/groups/calendar-admins.yaml
@@ -24,6 +24,8 @@ spec:
     role: MEMBER
   - email: andrey.velichkevich@gmail.com
     role: MEMBER
+  - email: mathew.wicks@gmail.com
+    role: MEMBER
   name: calendar-admins
   whoCanJoin: INVITED_CAN_JOIN
   whoCanPostMessage: ANYONE_CAN_POST


### PR DESCRIPTION
Currently, the Kubeflow Community Calendar is not being updated automatically when a new event is added.

Until we figure out the root cause, we are trying to see if we can manually update it.