### PR TITLE
Create Kubeflow SDK team

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -777,10 +777,20 @@ orgs:
             - yuzisun
             - yuzliu
             privacy: closed
+          kubeflow-sdk-team:
+            description: Maintainers of `kubeflow/sdk`
+            members:
+            - andreyvelich
+            - astefanutti
+            - Electronic-Waste
+            - kramaranya
+            - szaher
+            privacy: closed
           kubeflow-trainer-team:
             description: Maintainers of `kubeflow/trainer`
             members:
             - andreyvelich
+            - astefanutti
             - Electronic-Waste
             - johnugeorge
             - terrytangyuan


### PR DESCRIPTION
I updated the `kubeflow-trainer-team` and create a new `kubeflow-sdk-team`.

cc @kubeflow/wg-training-leads @astefanutti @Electronic-Waste @kramaranya @szaher 
