### PR TITLE
Create kubeflow-notebooks-security team

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -815,6 +815,14 @@ orgs:
             - varodrig
             - StefanoFioravanzo
             privacy: closed
+          kubeflow-notebooks-security:
+            description: Security reviewer role in kubeflow/notebooks
+            members:
+            - andyatmiami
+            - ederign
+            - paulovmr
+            - thesuperzapper
+            privacy: closed
           kubeflow-steering-committee:
             description: Kubeflow Steering Committee; Defined by Kubeflow governance
             members:
@@ -823,14 +831,6 @@ orgs:
             - johnugeorge
             - juliusvonkohout
             - terrytangyuan
-            privacy: closed
-          notebooks-security:
-            description: Security reviewer role in kubeflow/notebooks
-            members:
-            - andyatmiami
-            - ederign
-            - paulovmr
-            - thesuperzapper
             privacy: closed
           release-managers:
             description: Kubeflow Release Team - Managers


### PR DESCRIPTION
github-orgs git:(nb-security-team) pytest test_org_yaml.py                                                            (kind-kfp-standalone-3/default)
===================================================================== test session starts ======================================================================
platform darwin -- Python 3.13.3, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/ederign/src/kubeflow/internal-acls/github-orgs
collected 1 item

test_org_yaml.py .                                                                                                                                       [100%]

====================================================================== 1 passed in 0.05s =======================================================================