### PR TITLE
chore: create kubeflow-notebooks-security  team

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -13,7 +13,7 @@ orgs:
         - googlebot
         - james-jwu
         - johnugeorge
-        - juliusvonkohout 
+        - juliusvonkohout
         - krook
         - terrytangyuan
         - thelinuxfoundation
@@ -898,6 +898,14 @@ orgs:
               dashboard: write
               kubeflow: write
               notebooks: write
+          kubeflow-notebooks-security:
+            description: Team of Kubeflow Notebooks members who can review Security issues
+            members:
+            - andyatmiami
+            - paulovmr
+            - ederign
+            - thesuperzapper
+            privacy: closed
           wg-pipeline-leads:
             description: Team of Pipeline Working Group leads
             members:


### PR DESCRIPTION
In order to help the Kubeflow Notebooks WG to review/triage/prioritize security issues - we need the ability to grant users access to the Security tab in the kubeflow/notebooks repository.  Common GitHub roles are too permissive to more naturally accomplish this - as `write` access is typically required to "see" the Security tab with pertinent information.

This PR creates a `kubeflow-notebooks-security` team that through some magic of automation and custom roles (offered through GitHub enterprise) - allows users access to the 'Security' tab with granting elevated permissions in other areas of the repository.

As discussed in the working group call on August 28th - this team will initially be comprised of 4 members of the community:
- Mathew
- Myself
- Eder
- Paulo