### PR TITLE
add `read` permission to `kubeflow-notebooks-security` team

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -825,6 +825,11 @@ orgs:
             - paulovmr
             - thesuperzapper
             privacy: closed
+            repos:
+              # NOTE: we have created a custom "security" role on the Kubeflow org which inherits from the "read" role:
+              #       https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/about-custom-repository-roles
+              #       this is because peribolos only knows the standard roles, but will NOT remove the custom role as long as its inherited role is listed here.
+              notebooks: read
           kubeflow-steering-committee:
             description: Kubeflow Steering Committee; Defined by Kubeflow governance
             members:


### PR DESCRIPTION
This PR makes the `kubeflow-notebooks-security` have explicit `read` access on the `kubeflow/notebooks` repo. This is to ensure that peribolos will not remove the custom "security" role from the `kubeflow-notebooks-security` team.

Here is the relevant peribolos code: https://github.com/kubernetes-sigs/prow/blob/f49c6158b87edaa75d280c6b8f9ffd26b7ba3da7/cmd/peribolos/main.go#L1155