### PR TITLE
Migrating Spark History server MCP repo to Kubeflow

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -884,6 +884,7 @@ orgs:
             repos:
               model-registry: write
               spark-operator: write
+              mcp-apache-spark-history-server: write
           wg-deployment-leads:
             description: Team of Deployment Working Group leads
             members:


### PR DESCRIPTION

- Adding access for newly migrated repo to Kubeflow https://github.com/kubeflow/mcp-apache-spark-history-server/issues under WG leads for Data