### PR TITLE
add @ederign to wg-data-leads

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -875,6 +875,7 @@ orgs:
             - andreyvelich
             - ChenYi015
             - ckadner
+            - ederign
             - tarilabs
             - Tomcli
             - rareddy


### PR DESCRIPTION
- Eder made it to Approver on May 9th, 2025 with https://github.com/kubeflow/model-registry/pull/1091
- to support with Model Registry release process: https://github.com/kubeflow/model-registry/blob/main/RELEASE.md#instructions and other processes, we need him to be included into the github repo Maintainers:

https://github.com/kubeflow/internal-acls/blob/c947ac83ea102b47f9154f0997a348b05a99719e/github-orgs/kubeflow/org.yaml#L884-L885

p.s.: analogous to https://github.com/kubeflow/internal-acls/pull/793