### PR TITLE
Add @jtu-ampere as a Kubeflow member

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -258,6 +258,7 @@ orgs:
         - jsitu777
         - jstamel
         - jtfogarty
+        - jtu-ampere
         - judahrand
         - junggil
         - jzp1025


### PR DESCRIPTION
## Request to become a Kubeflow member
This PR is related to the following issue (https://github.com/kubeflow/internal-acls/issues/864)

Hello Kubeflow community, 
I've recently made a couple of contributions: a Kubeflow Pipelines change on Dockerfile.* for addressing multi-arch container image to support Arm64 platform and gave a lightning speech at Kubeflow Summit NA 2025.
- [feat(backend): Adding Multi-CPU architecture support in Dockerfile.* files for supporting Arm64 platform](https://github.com/kubeflow/pipelines/pull/12313)
- Gave a lightning talk ["Kubeflow in a Box - Streamlining MLOps Pipeline with Kubeflow on Arm64 locally"](https://sched.co/28D2K) at Kubeflow summit NA 2025.

I'm looking forward to getting more involved with the community!

## Membership sponsors
My membership sponsors are @chasecadet and @andreyvelich

## Test Results
<img width="1312" height="149" alt="pytest-result-20251119_162028" src="https://github.com/user-attachments/assets/339301cd-f7cb-4ec7-9f5f-5a8eac804cb0" />
