### PR TITLE
Add sduvvuri1603 to Kubeflow org

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -411,6 +411,7 @@ orgs:
         - ScorpioCPH
         - scottilee
         - ScrapCodes
+        - sduvvuri1603
         - sen-sam
         - seong7
         - shannonbradshaw


### PR DESCRIPTION
### Summary

Add sduvvuri1603 to the Kubeflow GitHub organization member list.

### Contributions to Kubeflow

Merged PR: [kubeflow/pipelines#12377 ](https://github.com/kubeflow/pipelines/pull/12377)– Optional runtime parameters fix
Merged PR: [kubeflow/pipelines#12399](https://github.com/kubeflow/pipelines/pull/12399) – Refine optional Kubernetes runtime test pipeline
Merged PR: [kubeflow/pipelines#12401](https://github.com/kubeflow/pipelines/pull/12401) – Remove unused Semaphore_key and mutex_name fields
Open PR: [kubeflow/pipelines#12442](https://github.com/kubeflow/pipelines/pull/12442) – Add pipeline run parallelism config