### PR TITLE
Add ppadti as a kubeflow member

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -363,6 +363,7 @@ orgs:
         - pdmack
         - pineking
         - pingsutw
+        - ppadti
         - pratyusharavi
         - pschoen-itsc
         - pugangxa


### PR DESCRIPTION
Related issue https://github.com/kubeflow/internal-acls/issues/873
Sponsors: @ederign @mturley  @manaswinidas 

============================= test session starts ==============================
platform darwin -- Python 3.14.2, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/ppadti/Documents/kubeflow-acls/internal-acls/github-orgs
collected 1 item

test_org_yaml.py .                                                       [100%]

============================== 1 passed in 0.24s ===============================