### PR TITLE
Add @jesuino as Member of Kubeflow org

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -233,6 +233,7 @@ orgs:
         - JerT33
         - jessesuen
         - jessiezcc
+        - jesuino
         - ji-yaqi
         - jiahaoc1993
         - jian-he


### PR DESCRIPTION
# Membership Request

This issue adds @jesuino as a member and closes https://github.com/kubeflow/internal-acls/issues/878. He has consistently contributed to Kale through multiple PRs and PR reviews.

### Provide links to your PRs or other contributions (2-3):
- https://github.com/kubeflow/kale/pull/536
- https://github.com/kubeflow/kale/pull/534
- https://github.com/kubeflow/kale/pull/518
- https://github.com/kubeflow/kale/pull/485
- https://github.com/kubeflow/kale/pull/477
- https://github.com/kubeflow/kale/pull/470

### List 2 existing members who are sponsoring your membership:
@ederign @StefanoFioravanzo 


========================================================== test session starts ===========================================================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/ederign/src/kubeflow/internal-acls/github-orgs
collected 1 item                                                                                                                         

test_org_yaml.py .                                                                                                                 [100%]

=========================================================== 1 passed in 0.05s ============================================================
➜  github-orgs git:(add-jesuino)