### PR TITLE
add kubeflow-hub-team with Write to KF/model-registry

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -798,14 +798,10 @@ orgs:
             description: Maintainers of `kubeflow/model-registry` (aka "Kubeflow Hub")
             members:
             - Al-Pragliola
-            - andreyvelich
-            - ckadner
             - ederign
             - pboyd
             - rareddy
             - tarilabs
-            - Tomcli
-            - zijianjoy
             privacy: closed
             repos:
               model-registry: write


### PR DESCRIPTION
similarly to other Maintainers team on a per-repo basis, this one focused on the kubeflow/model-registry repo, also known as "Kubeflow Hub".

Please note the intent of this team is indeed to focus only on this repository, so to enable the chore processes across the current list of OWNERS.approvers: https://github.com/kubeflow/model-registry/blob/272a5f6be87b258b9cecc1f2687a08748bb1fed8/OWNERS#L2C1-L10C14 
specifically:
- performing the Release process (https://github.com/kubeflow/model-registry/blob/272a5f6be87b258b9cecc1f2687a08748bb1fed8/RELEASE.md)
- delegate wider access to Security reports

at the time of writing, in pragmatic term, the above relies on a bus-factor of 2 (+1 one Manager role) so with aligning best practice in defining a team for the specific repo needs we standardadize across the Kubeflow community and provide complete ownership for all repo-related processes.

cc @kubeflow/kubeflow-steering-committee @andreyvelich 