### PR TITLE
Add Tomas Tormo as a Kubeflow member

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -264,6 +264,7 @@ orgs:
         - judahrand
         - junggil
         - jzp1025
+        - kaisoz
         - kandrio
         - kannon92
         - karlschriek


### PR DESCRIPTION
# Membership Request

## GitHub Username
kaisoz

### Links to contributions
* [[Issue]The admission webhook rejects TrainJobs with more than one PodSpecOverride targeting the same job
](https://github.com/kubeflow/trainer/issues/2871)
* [[Issue]Allow building Runtime Info objects from other packages
](https://github.com/kubeflow/trainer/issues/2836)
* [[PR] feat: Add a public function to create runtime info objects](https://github.com/kubeflow/trainer/pull/2837)
* [[PR] fix: Allow multiple podSpec overrides to target the same TargetJob](https://github.com/kubeflow/trainer/pull/2880)
* [[PR] feat: Add the manager field to the podTemplateOverride object](https://github.com/kubeflow/trainer/pull/3020) (under review)

### List 2 existing members who are sponsoring your membership:
@andreyvelich @astefanutti 