### PR TITLE
Add @ada333 as Member of Kubeflow org

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -35,6 +35,7 @@ orgs:
         - abhijeet-dhumal
         - abkosar
         - achalshant
+        - ada333
         - AdamKorcz
         - adrian555
         - adriangonz


### PR DESCRIPTION
# Membership Request

This issue adds @ada333 as a member and closes https://github.com/kubeflow/internal-acls/issues/894. He has consistently contributed to Kale through multiple PRs and PR reviews.

### Provide links to your PRs or other contributions (2-3):
- https://github.com/kubeflow/kale/pull/639
- https://github.com/kubeflow/kale/pull/620
- https://github.com/kubeflow/kale/pull/596
- https://github.com/kubeflow/kale/pull/617
- https://github.com/kubeflow/kale/pull/579
- https://github.com/kubeflow/kale/pull/595
- https://github.com/kubeflow/kale/pull/532
- https://github.com/kubeflow/kale/pull/543
- https://github.com/kubeflow/kale/pull/520
- https://github.com/kubeflow/kale/pull/512
- https://github.com/kubeflow/kale/pull/499
- https://github.com/kubeflow/kale/pull/493
- https://github.com/kubeflow/kale/pull/484

### List 2 existing members who are sponsoring your membership:
@ederign @hmtosi @jesuino @StefanoFioravanzo 

### Sanity Check 
================================================ test session starts =================================================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/ederign/src/kubeflow/internal-acls/github-orgs
collected 1 item                                                                                                     

test_org_yaml.py .                                                                                             [100%]

================================================= 1 passed in 0.05s ==================================================
➜  github-orgs git:(add-adam) 