### PR TITLE
Remove google-admin from members

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -194,7 +194,6 @@ orgs:
         - Garrybest
         - gkcalat
         - gmfrasca
-        - google-admin
         - goswamig
         - gregsheremeta
         - greynutw


### PR DESCRIPTION
We've been repeatedly receiving org membership invitations on the google-admin account although we no longer manage Kubeflow. Please remove google-admin from the membership automation, thanks!