### PR TITLE
Add members to Kubeflow Release Team

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -892,6 +892,8 @@ orgs:
             description: Kubeflow Release Team - Managers
             members:
               - varodrig
+              - tarekabouzeid
+              - juliusvonkohout
             privacy: closed
             repos:
               kubeflow: write


### PR DESCRIPTION
Otherwise we are automatically removed from the group https://github.com/orgs/kubeflow/teams/release-managers/members