### PR TITLE
feat: add cybernagle as kubeflow org member

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -125,6 +125,7 @@ orgs:
         - cspavlou
         - cvenets
         - cwbeitel
+        - cybernagle
         - dandawg
         - danisla
         - Davidnet


### PR DESCRIPTION
Closes #902

## Summary

Add @cybernagle to the Kubeflow GitHub org members list.

## Contributions

**kubeflow/pipelines:**
- fix(security): validate namespace to prevent SSRF (CVE-2023-6570) — https://github.com/kubeflow/pipelines/pull/13126 (merged)
- fix(security): prevent SQL injection in pageToken via field name validation — https://github.com/kubeflow/pipelines/pull/13127 (open)
- feat(metadata-writer): add METADATA_GRPC_MAX_RECEIVE_MESSAGE_LENGTH config — https://github.com/kubeflow/pipelines/pull/12438 (merged)
- fix(backend): get pipeline by name broken due to version typo — https://github.com/kubeflow/pipelines/pull/10268 (merged)

**kubeflow/manifests:**
- feat: add doc to describe use oauth2proxy directly — https://github.com/kubeflow/manifests/pull/2884 (merged)
- fix: wrong diagram path for kubeflow auth — https://github.com/kubeflow/manifests/pull/2862 (merged)
- fix: istio 1.70 envoy filter chain — https://github.com/kubeflow/manifests/pull/2656 (merged)

## Test output

```
============================= test session starts ==============================
platform darwin -- Python 3.14.3, pytest-9.0.2, pluggy-1.6.0 -- /opt/homebrew/opt/python@3.14/bin/python3.14
cachedir: .pytest_cache
rootdir: /Users/I530319/Library/CloudStorage/OneDrive-SAPSE/Desktop/SAPDevelop/internal-acls/github-orgs
plugins: Faker-40.12.0
collecting ... collected 1 item

test_org_yaml.py::test_team_member_is_in_org PASSED                      [100%]

============================== 1 passed in 0.53s ===============================
```