### PR TITLE
Add tariq-hasan as kubeflow member

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -457,6 +457,7 @@ orgs:
         - Tabrizian
         - tarekabouzeid
         - tarilabs
+        - tariq-hasan
         - tasos-ale
         - tedhtchang
         - tenzen-y


### PR DESCRIPTION
# Membership Request
This PR adds @tariq-hasan as member of the Kubeflow GitHub organization.

## Contributions
**kubeflow/spark-operator:**
* kubeflow/spark-operator#2808
* kubeflow/spark-operator#2828
* kubeflow/spark-operator#2853
* kubeflow/spark-operator#2862

**kubeflow/trainer:**
* kubeflow/trainer#2028
* kubeflow/trainer#2150

**kubeflow/katib:**
* kubeflow/katib#2289
* kubeflow/katib#2316
* kubeflow/katib#2325
* kubeflow/katib#2375
* kubeflow/katib#2384

**kubeflow/sdk:**
* kubeflow/sdk#295
* kubeflow/sdk#360

**kubeflow/kubeflow:**
* kubeflow/kubeflow#7637

## Sponsors
* @andreyvelich
* @Shekharrajak

## Sanity Check
```shell
pytest github-orgs/test_org_yaml.py
```

```
======================================================================= test session starts =======================================================================
platform darwin -- Python 3.9.12, pytest-7.2.0, pluggy-1.0.0
rootdir: /Users/tariqhasan/Projects/open_source/internal-acls
plugins: anyio-3.6.2
collected 1 item                                                                                                                                                  

github-orgs/test_org_yaml.py .                                                                                                                              [100%]

======================================================================== 1 passed in 0.19s ========================================================================
```