### PR TITLE
Add @aniket2405 to Kubeflow members

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -64,6 +64,7 @@ orgs:
         - andyatmiami
         - anencore94
         - anfeng
+        - aniket2405
         - animeshsingh
         - anishasthana
         - annajung


### PR DESCRIPTION
# Membership Request
This PR adds @aniket2405 as a member of the Kubeflow GitHub organization.

## Contributions

**kubeflow/trainer:**
* kubeflow/trainer#3281

**kubeflow/katib:**
* kubeflow/katib#2657
* kubeflow/katib#2624

**kubernetes-sigs:**
* kubernetes-sigs/jobset#1147
* kubernetes-sigs/jobset#1179

## Sponsors
* @andreyvelich
* @akshaychitneni

## Sanity Check
```shell
python -m pytest test_org_yaml.py
```

```
=============================================== test session starts ===============================================
platform darwin -- Python 3.14.3, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/aniket.shaha/Desktop/OS/internal-acls/github-orgs
collected 1 item                                                                                                  

test_org_yaml.py .                                                                                          [100%]

================================================ 1 passed in 0.06s ================================================
```