### PR TITLE
Add @nabuskey to wg-data-leads

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -976,12 +976,12 @@ orgs:
             - ChenYi015
             - ckadner
             - ederign
+            - nabuskey
             - tarilabs
             - Tomcli
             - rareddy
             - vara-bonthu
             - yuchaoran2011
-            - nabuskey
             privacy: closed
             repos:
               hub: write

--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -981,6 +981,7 @@ orgs:
             - rareddy
             - vara-bonthu
             - yuchaoran2011
+            - nabuskey
             privacy: closed
             repos:
               hub: write


### PR DESCRIPTION
I am nominating myself to be added to the wg-data-leads group. 

- I've been a reviewer for the spark operator and spark history server mcp server for 1.5 years.
- Reviewed 50+ PRs
- Opened a PR to move myself to approver from reviewer: https://github.com/kubeflow/spark-operator/pull/2944

