### PR TITLE
add Vedant-Deshpande in the members list

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -28,6 +28,7 @@ orgs:
         has_repository_projects: true
         location: ""
         members:
+        - roburishabh
         - 8bitmp3
         - abcdefgs0324
         - abchoo


### PR DESCRIPTION
Hi, I'd like to join the Kubeflow GitHub organization.
## Contributions
I have been actively contributing to the [kubeflow/spark-operator](https://github.com/kubeflow/spark-operator) repository. Here are 3 significant merged PRs:
1. **fix(webhook): Fix path for mutating ScheduledSparkApplication, correct sideEffects, remove update verb in manifests** (size/L)
   https://github.com/kubeflow/spark-operator/pull/2915
2. **feat(pdb): Add PodDisruptionBudget Kustomize resource for controller-manager** (size/S)
   https://github.com/kubeflow/spark-operator/pull/2918
3. **feat(prometheus): Add Prometheus PodMonitor Kustomize resource** (size/S)
   https://github.com/kubeflow/spark-operator/pull/2922
## Sponsors
- @nabuskey
- @franciscojavierarceo
## Test output
```
======================================================= test session starts =======================================================
platform darwin -- Python 3.14.0, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/vedeshpa/Documents/GitHub/internal-acls/internal-acls
collected 1 item                                                                                                                  

github-orgs/test_org_yaml.py .                                                                                              [100%]

======================================================== 1 passed in 0.09s ========================================================
```