### PR TITLE
Add Dhanisha Phadate as Kubeflow member

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -144,6 +144,7 @@ orgs:
         - DeliangFan
         - denkensk
         - derekhh
+        - dhanishaphadate
         - DharmitD
         - dhirajsb
         - diegolovison


### PR DESCRIPTION
# Membership Request

This PR adds @dhanishaphadate  as members of the Kubeflow GitHub organization.

## Sponsors
- @juliusvonkohout
- @tarekabouzeid 

## Sanity Check
```bash
cd github-orgs
pytest test_org_yaml.py
```

```
==================================================================================== test session starts ====================================================================================
platform darwin -- Python 3.13.7, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/d_phadate/project/k8s_community/kubeflow/internal-acls
collected 1 item                                                                                                                                                                            

github-orgs/test_org_yaml.py .                                                                                                                                                        [100%]

===================================================================================== 1 passed in 0.28s =====================================================================================
(.venv) d_phadate@Mac internal-acls % 

```