### PR TITLE
Add philip-carneiro as a kubeflow member

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -378,6 +378,7 @@ orgs:
         - paveldournov
         - pboyd
         - pdmack
+        - philip-carneiro
         - pineking
         - pingsutw
         - ppadti


### PR DESCRIPTION
Related issue https://github.com/kubeflow/internal-acls/issues/916
Sponsors: @ppadti @manaswinidas @mturley @YuliaKrimerman
================================= test session starts =======================================
platform darwin -- Python 3.13.7, pytest-8.2.0, pluggy-1.6.0
rootdir: /Users/pcarneir/Repos/kubeflow/internal-acls
collected 1 item                                                                                                                                                                                                                                                                                                                                                                                        

github-orgs/test_org_yaml.py .                                                                                                                                                                                                                                                                                                                                                                    [100%]
================================= 1 passed in 0.05s ========================================