### PR TITLE
Update KSC ownership for 2026

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,12 +1,13 @@
 approvers:
   - andreyvelich
+  - chasecadet
   - franciscojavierarceo
   - juliusvonkohout
-  - johnugeorge
-  - terrytangyuan
+  - thesuperzapper
   - zijianjoy
 
 emeritus_approvers:
   - james-jwu
   - jbottum
-
+  - johnugeorge
+  - terrytangyuan

--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -11,11 +11,13 @@ orgs:
         - franciscojavierarceo
         - google-oss-robot
         - googlebot
+        - chasecadet
         - james-jwu
         - johnugeorge
         - juliusvonkohout
         - krook
         - terrytangyuan
+        - thesuperzapper
         - thelinuxfoundation
         - zijianjoy
         billing_email: vishnukanan@gmail.com
@@ -894,10 +896,10 @@ orgs:
             description: Kubeflow Steering Committee; Defined by Kubeflow governance
             members:
             - andreyvelich
+            - chasecadet
             - franciscojavierarceo
-            - johnugeorge
             - juliusvonkohout
-            - terrytangyuan
+            - thesuperzapper
             privacy: closed
           release-managers:
             description: Kubeflow Release Team - Managers

--- a/github-orgs/manifests/validate_config.py
+++ b/github-orgs/manifests/validate_config.py
@@ -29,10 +29,10 @@ class CheckConfig(object):
 
     # TODO(jlewi): We should load this in via config map
     # Check that each admin is in a whitelist set of admins.
-    allowed_admins = ["andreyvelich", "caniszczyk", "chensun", "franciscojavierarceo", "googlebot",
-                      "google-oss-robot", "james-jwu", "jbottum", "jlewi", "johnugeorge", "juliusvonkohout",
-                      "k8s-ci-robot", "krook", "thelinuxfoundation",
-                      "terrytangyuan", "zijianjoy"]
+    allowed_admins = ["andreyvelich", "caniszczyk", "chasecadet", "chensun", "franciscojavierarceo",
+                      "googlebot", "google-oss-robot", "james-jwu", "jbottum", "jlewi", "johnugeorge",
+                      "juliusvonkohout", "k8s-ci-robot", "krook", "terrytangyuan", "thesuperzapper",
+                      "thelinuxfoundation", "zijianjoy"]
 
     for a in admins:
       if not a in allowed_admins:


### PR DESCRIPTION
Updates the 2026 Kubeflow Steering Committee ownership config.

Changes:
- update OWNERS to reflect the 2026 KSC membership
- add chasecadet and thesuperzapper to the org admin allowlist
- update the kubeflow-steering-committee team membership in org.yaml
- keep existing admins who are still referenced by other teams so repo validation remains green

Validation:
- python github-orgs/test_org_yaml.py
- python github-orgs/manifests/validate_config.py check_config github-orgs/kubeflow/org.yaml

Related: kubeflow/community#950