### PR TITLE
Fix Kubeflow Admins for KSC 2026

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -13,10 +13,8 @@ orgs:
         - googlebot
         - chasecadet
         - james-jwu
-        - johnugeorge
         - juliusvonkohout
         - krook
-        - terrytangyuan
         - thesuperzapper
         - thelinuxfoundation
         - zijianjoy
@@ -109,7 +107,6 @@ orgs:
         - ChanYiLin
         - chaselyall
         - chambridge
-        - chasecadet
         - chauhang
         - cheimu
         - ChenYi015
@@ -263,6 +260,7 @@ orgs:
         - JOCSTAA
         - joeliedtke
         - JohanWork
+        - johnugeorge
         - jonburdo
         - Jose-Matsuda
         - jose5918
@@ -467,11 +465,11 @@ orgs:
         - tasos-ale
         - tedhtchang
         - tenzen-y
+        - terrytangyuan
         - texasmichelle
         - thaorell
         - thedriftofwords
         - theofpa
-        - thesuperzapper
         - tmckayus
         - TobiasGoerke
         - tombuuz


### PR DESCRIPTION
When persons are added as admin, we should remove them from the org list.

Currently, our CI job is failing:
```
k get pods -n github-admin
NAME                             READY   STATUS      RESTARTS   AGE
github-sync-29686690-kpvj4       0/1     Error       0          106s
github-sync-29686690-nq4rs       0/1     Error       0          2m
github-sync-29686690-tz2kr       0/1     Error       0          81s
```

/assign @franciscojavierarceo @thesuperzapper @chasecadet @juliusvonkohout 