### PR TITLE
Fix fallout of #921

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -883,6 +883,8 @@ orgs:
             - juliusvonkohout
             - tarekabouzeid
             privacy: closed
+            repos:
+              community-distribution: write
           kubeflow-notebooks-security:
             description: Security reviewer role in kubeflow/notebooks
             members:


### PR DESCRIPTION
in https://github.com/kubeflow/internal-acls/pull/921/changes you accidentally removed 

```
          wg-manifests-leads:
            description: Team of Manifests Working Group Leads
            members:
            - juliusvonkohout
            - kimwnasptd
            privacy: closed
            repos:
              manifests: write
```
but forgot to add back

```
            repos:
              community-distribution: write
```

@andreyvelich @franciscojavierarceo 