### PR TITLE
Add @Sridhar1030 to Kubeflow members

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -445,6 +445,7 @@ orgs:
         - sijieamoy
         - songole
         - sperlingxx
+        - Sridhar1030
         - sshrdp
         - StefanoFioravanzo
         - stpabhi


### PR DESCRIPTION
# Membership Request
This PR adds @Sridhar1030 as a member of the Kubeflow GitHub organization.

## Contributions

**kubeflow/trainer:**
* kubeflow/trainer#3308
* kubeflow/trainer#3490
* kubeflow/trainer#3540

**kubeflow/pipelines:**
* kubeflow/pipelines#13009
* kubeflow/pipelines#12884

## Sponsors
* @andreyvelich
* @abhijeet-dhumal

## Sanity Check
```shell
python3 -m pytest test_org_yaml.py
```

```
============================= test session starts ==============================
platform darwin -- Python 3.14.3, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/srpillai/CODING/internal-acls/github-orgs
plugins: anyio-4.12.1, timeout-2.4.0
collected 1 item

test_org_yaml.py .                                                       [100%]

============================== 1 passed in 0.12s ===============================
```