### PR TITLE
chore: add dominikkawka to kubeflow members

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -154,6 +154,7 @@ orgs:
         - dmueller2001
         - DnPlas
         - DomFleischmann
+        - Dominikkawka
         - Doris-xm
         - dpoulopoulos
         - dreamryx


### PR DESCRIPTION
see #931

cc: @christian-heusel @varodrig 

```
dkawka@fedora:~/internal-acls$ pytest github-orgs/test_org_yaml.py 
========================================================== test session starts ===========================================================
platform linux -- Python 3.14.5, pytest-8.3.5, pluggy-1.6.0
rootdir: /home/dkawka/internal-acls
plugins: anyio-4.13.0
collected 1 item                                                                                                                         

github-orgs/test_org_yaml.py .                                                                                                     [100%]

=========================================================== 1 passed in 0.12s ============================================================

```