### PR TITLE
Add @jaewak to Kubeflow members

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -232,6 +232,7 @@ orgs:
         - IRONICBo
         - IronPan
         - jacobsalway
+        - jaewak
         - jagadeeshi2i
         - jaiakash
         - janeman98


### PR DESCRIPTION
### Membership Request
This PR adds @jaewak as a member of the Kubeflow GitHub organization.

### Contributions

kubeflow/pipelines:
https://github.com/kubeflow/pipelines/pull/13440
https://github.com/kubeflow/pipelines/pull/13472

Sponsors
@droctothorpe 
@jeffspahr 

### Sanity Check

```
➜  github-orgs git:(patch-1) /tmp/pytest-venv/bin/python -m pytest test_org_yaml.py
================================================================================================ test session starts =================================================================================================
platform darwin -- Python 3.14.3, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/jaewak/workspace/internal-acls/github-orgs
collected 1 item

test_org_yaml.py .                                                                                                                                                                                             [100%]

================================================================================================= 1 passed in 0.04s ==================================================================================================
```