### PR TITLE
Add Krishna-kg732 as Kubeflow org member

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -299,6 +299,7 @@ orgs:
         - knkski
         - kramachandran
         - kramaranya
+        - Krishna-kg732
         - krishnadurai
         - kromanow94
         - krzyzacy


### PR DESCRIPTION
Adding @Krishna-kg732 to the Kubeflow org members.

Krishna has been actively contributing across Kubeflow Trainer and MCP Server.

**kubeflow/trainer**
- https://github.com/kubeflow/trainer/pull/3200 
- https://github.com/kubeflow/trainer/pull/3118
- https://github.com/kubeflow/trainer/pull/3225
- https://github.com/kubeflow/trainer/pull/3536
- https://github.com/kubeflow/trainer/pull/3323

**kubeflow/mcp-server**
- https://github.com/kubeflow/mcp-server/pull/28
- https://github.com/kubeflow/mcp-server/pull/48 

Sponsors:
@abhijeet-dhumal
@jaiakash 

/cc @andreyvelich @kubeflow/kubeflow-sdk-team @kubeflow/kubeflow-trainer-team 