### PR TITLE
Add @siyuanfoundation as Member of Kubeflow org

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -447,6 +447,7 @@ orgs:
         - shivchander
         - shrinath-suresh
         - sijieamoy
+        - siyuanfoundation
         - Snehadas2005
         - songole
         - sperlingxx


### PR DESCRIPTION
**Membership Request: @siyuanfoundation**
This PR adds siyuanfoundation as a project member.

**Key Contributions**
- https://github.com/kubeflow/notebooks/pull/1131
- https://github.com/kubeflow/notebooks/pull/1127
- https://github.com/kubeflow/notebooks/pull/1130

**Sponsors**
This request is supported and sponsored by the following existing members:
@andyatmiami