### PR TITLE
chore: add abhijeet-dhumal to kubeflow-sdk-team

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -848,6 +848,7 @@ orgs:
           kubeflow-sdk-team:
             description: Maintainers of `kubeflow/sdk`
             members:
+            - abhijeet-dhumal
             - andreyvelich
             - astefanutti
             - Electronic-Waste


### PR DESCRIPTION
## Description

Add @abhijeet-dhumal to `kubeflow-sdk-team` for write access to `kubeflow/sdk`and `kubeflow/mcp-server` maintenance.

## Context

Active maintainer on `kubeflow/mcp-server` reviewing/merging PRs, triaging issues, and coordinating releases. Team membership required for OWNERS approval
rights and CI write-access labels.

cc @andreyvelich @kubeflow/kubeflow-sdk-team @thesuperzapper 