### PR TITLE
chore: remove yehudit1987 from Kubeflow org

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -513,7 +513,6 @@ orgs:
         - yashpal2104
         - yebrahim
         - yeya24
-        - yehudit1987
         - yhwang
         - yilun-msft
         - yixinshi


### PR DESCRIPTION
Removes the `yehudit1987` entry from the Kubeflow org members list because that GitHub account no longer exists, which was causing peribolos to fail with a 404 on `UpdateOrgMembership` and a fatal 422 that broke CI. Change touches `github-orgs/kubeflow/org.yaml`.

_This PR was created using AI tools._