### PR TITLE
Remove sarahmaddox from the GitHub org

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -428,7 +428,6 @@ orgs:
         - salehay
         - sambaiz
         - sandipanpanda
-        - sarahmaddox
         - sasha-gitg
         - saurabh24292
         - ScorpioCPH


### PR DESCRIPTION
Removing @sarahmaddox from the org list. @sarahmaddox Let us know if you still want to be involved in Kubeflow work!

Our CI sync still fails with this error:

```
(kubeflow, sarahmaddox, false)","severity":"info","time":"2026-07-21T13:00:20Z"}
{"client":"github","component":"peribolos","file":"k8s.io/test-infra/prow/github/client.go:1191","func":"k8s.io/test-infra/prow/github.(*client).doRequest","level":"info","msg":"Using GitHub REST API Version: 2022-11-28","severity":"info","time":"2026-07-21T13:00:20Z"}
{"component":"peribolos","error":"status code 422 not one of [200], body: {\"message\":\"The request could not be processed.\",\"documentation_url\":\"https://docs.github.com/rest/orgs/members#set-organization-membership-for-a-user\",\"status\":\"422\"}","file":"k8s.io/test-infra/prow/cmd/peribolos/main.go:477","func":"main.configureOrgMembers.func1","level":"warning","msg":"UpdateOrgMembership(kubeflow, sarahmaddox, false) failed","severity":"warning","time":"2026-07-21T13:00:20Z"}
```

This might happen when user doesn't accept invite for a long time, so we should remove it.


/assign @christian-heusel @franciscojavierarceo @chasecadet @thesuperzapper @juliusvonkohout 