### PR TITLE
Add Goku2099 as Kubeflow org member

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -200,6 +200,7 @@ orgs:
         - gkcalat
         - gmfrasca
         - goswamig
+        - Goku2099
         - gregsheremeta
         - greynutw
         - Griffin-Sullivan

--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -199,8 +199,8 @@ orgs:
         - Garrybest
         - gkcalat
         - gmfrasca
-        - goswamig
         - Goku2099
+        - goswamig
         - gregsheremeta
         - greynutw
         - Griffin-Sullivan


### PR DESCRIPTION
Adding @Goku2099 to the Kubeflow organization members.


### kubeflow/sdk

- feat: [KEP-107] Add Spark batch job submission and lifecycle APIs
  https://github.com/kubeflow/sdk/pull/521

- feat: [KEP-107] Add long-running job submission proposal for SparkClient
  https://github.com/kubeflow/sdk/pull/524

- chore: Improve Spark SDK documentation with connection and session management
  https://github.com/kubeflow/sdk/pull/537

- chore: Rename `SparkConnectInfo.pod_name` to `driver_pod_name`
  https://github.com/kubeflow/sdk/pull/546

- feat: [KEP-107] Add FuncJob support for Python function submission
  https://github.com/kubeflow/sdk/pull/629

### kubeflow/trainer

- chore: Use named ports for manager deployment and service
  https://github.com/kubeflow/trainer/pull/3100

- fix: Enable read-only root filesystem for trainer manager
  https://github.com/kubeflow/trainer/pull/3119

- chore: Unit tests for runtime registry and RuntimeInfo error handling
  https://github.com/kubeflow/trainer/pull/3168

- fix: Align `torchao` with `torch` 2.9.1 to fix GPU e2e failure
  https://github.com/kubeflow/trainer/pull/3203

- feat: Code Quality Checks workflow
  https://github.com/kubeflow/trainer/pull/3224

- fix: Align torch-distributed-with-cache runtime logic with unit tests
  https://github.com/kubeflow/trainer/pull/3226

- feat: Helm test workflow
  https://github.com/kubeflow/trainer/pull/3228

- feat: Add e2e tests to Helm CI workflow
  https://github.com/kubeflow/trainer/pull/3253

- chore: Add `timeout-minutes` to GPU e2e test workflow
  https://github.com/kubeflow/trainer/pull/3329

Sponsors:
- @tariq-hasan 
- @Shekharrajak 
- @andreyvelich 

/cc @andreyvelich @kubeflow/kubeflow-sdk-team @kubeflow/kubeflow-trainer-team