### PR TITLE
chore: add members to security-team for spark-operator CVE fixes

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -56,6 +56,7 @@ orgs:
         - alexlatchford
         - alexmt
         - alfsuse
+        - alimaredia
         - alinakuz
         - alsrgv
         - alyssacgoins
@@ -487,6 +488,7 @@ orgs:
         - vikas-saxena02
         - vincent-pli
         - vishh
+        - vjanelle
         - vkoukis
         - vpavlin
         - vrajjbhatt
@@ -937,6 +939,7 @@ orgs:
             members:
             - abhijeet-dhumal
             - AdamKorcz
+            - alimaredia
             - andreyvelich
             - andyatmiami
             - astefanutti
@@ -959,13 +962,17 @@ orgs:
             - paulovmr
             - pboyd
             - rareddy
+            - roburishabh
             - szaher
             - tarilabs
             - tenzen-y
+            - tariq-hasan
             - terrytangyuan
             - thesuperzapper
             - vara-bonthu
             - varodrig
+            - vikas-saxena02
+            - vjanelle
             - zazulam
             privacy: closed
             repos:


### PR DESCRIPTION
## Summary

1. Add @alimaredia and @vjanelle to Kubeflow org members list.
2. Add @RobuRishabh, @alimaredia, @vikas-saxena02, @vjanelle, and @tariq-hasan to the `security-team` so they can work on fixing CVEs in the spark-operator repo.

## Test output

```
============================= test session starts ==============================
platform darwin -- Python 3.13.7, pytest-9.0.3, pluggy-1.6.0
collected 1 item

test_org_yaml.py::test_team_member_is_in_org PASSED                      [100%]

============================== 1 passed in 0.08s ===============================
```

cc: @andreyvelich