### PR TITLE
Add @saivedant169 as Member of Kubeflow org

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -425,6 +425,7 @@ orgs:
         - ryansteakley
         - ryantd
         - SachinVarghese
+        - saivedant169
         - salanki
         - salehay
         - sambaiz


### PR DESCRIPTION
**Membership Request: @saivedant169**

This PR adds saivedant169 as a member of the Kubeflow org.

**Key Contributions**
- https://github.com/kubeflow/katib/pull/2666
- https://github.com/kubeflow/katib/pull/2679
- https://github.com/kubeflow/katib/pull/2685
- https://github.com/kubeflow/katib/pull/2689
- https://github.com/kubeflow/trainer/issues/3743

**Sponsors**
This request is supported and sponsored by the following existing members:
@andreyvelich

**Test output**

```
$ cd github-orgs && pytest test_org_yaml.py
============================= test session starts ==============================
platform darwin -- Python 3.14.5, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/saivedanthava/internal-acls/github-orgs
collected 1 item

test_org_yaml.py .                                                       [100%]

============================== 1 passed in 1.18s ===============================
```
