### PR TITLE
Add kmr-rohit as Member of Kubeflow org

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -296,6 +296,7 @@ orgs:
         - KingOnTheStar
         - kkasravi
         - kmarquardsen
+        - kmr-rohit
         - knkski
         - kramachandran
         - kramaranya


### PR DESCRIPTION
**Membership Request: @kmr-rohit**

This PR adds `kmr-rohit` to the `org.kubeflow.members` list. Tracking issue: kubeflow/internal-acls#XXX

I contribute to `kubeflow/docs-agent`, where I work on the retrieval pipelines, the MCP server, and the A2A gateway that fronts the public documentation chatbot. I am also a GSoC 2026 contributor on that project.

**Key Contributions** (`kubeflow/docs-agent`)

- https://github.com/kubeflow/docs-agent/pull/210 — 3-tool MCP server, TEI embeddings, GitHub issues + code ingestion pipelines, OKE CI/CD
- https://github.com/kubeflow/docs-agent/pull/218 — Istio edge config migrated to a `gateway-guardrails` Helm chart (rate limiting + CORS lockdown)
- https://github.com/kubeflow/docs-agent/pull/219 — anonymous session-JWT auth for the public chatbot gateway
- https://github.com/kubeflow/docs-agent/issues/216, https://github.com/kubeflow/docs-agent/issues/217 — bug reports with root-cause analysis; #216 was picked up and fixed by another contributor in #212
- https://github.com/kubeflow/docs-agent/issues/59, https://github.com/kubeflow/docs-agent/pull/207 — design discussion and review participation

**Sponsors**

This request is sponsored by the following existing members:

- @chasecadet
- @tarekabouzeid

**Test output**

```
$ pytest github-orgs/test_org_yaml.py
======================== test session starts ========================
platform darwin -- Python 3.13.5, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/rohitkumar/Downloads/Coding/Opensource/internal-acls
plugins: asyncio-1.3.0, anyio-4.7.0, langsmith-0.7.17
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1 item

github-orgs/test_org_yaml.py .                                [100%]

========================= 1 passed in 0.04s =========================
```
