### PR TITLE
add modichika(Shristi) as a Kubeflow Org Member

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -344,10 +344,10 @@ orgs:
         - milosjava
         - mitake
         - mkbhanda
+        - modichika
         - moficodes
         - mosabami
         - moxyoron
-        - modichika
         - mprahl
         - mpvartak
         - MrXinWang

--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -347,6 +347,7 @@ orgs:
         - moficodes
         - mosabami
         - moxyoron
+        - modichika
         - mprahl
         - mpvartak
         - MrXinWang


### PR DESCRIPTION
**Membership Request:** @modichika 

This PR adds `modichika` to the `org.kubeflow.members`  list. 
Tracking Issue: [kubeflow/internal-acls_Issue-958](https://github.com/kubeflow/internal-acls/issues/958)

I am an active contributor to kubeflow/pipelines, kubeflow/trainer, and kubeflow/mcp-server, where my work involves tackling low-level and high-level feature additions, solving bugs, backend work, Kubernetes CRDs, and adding `OptimizationJob ` to the trainer repository.

**Key Contributions(`kubeflow/pipelines`, `kubeflow/mcp-server`):** 

- https://github.com/kubeflow/pipelines/pull/13372 ---- An AI-Powered issue analyzer that analyzes GitHub issues as soon as it opens. It uses 'gpt-4o-mini' via GitHub Models, which is free, fast, and provides clear reasoning divided under: scope, context and guidance, complexity, overall issue quality verdict.

- https://github.com/kubeflow/pipelines/pull/14022 --- Instead of loading full GH issues into the prompt context (which is more expensive, token-wise) and failing, we proposed an algorithm that depends on the type of issue identified; the script compares each section of the issue to the sample text and then feeds it to the LLM.

- https://github.com/kubeflow/mcp-server/pull/6 ---- I helped @abhijeet-dhumal review this PR that replaces the earlier co-located test layout with a tests/unit scaffold and adds shared harness fixtures for core and trainer modules.

- https://github.com/kubeflow/pipelines/pull/13653  ---- This PR adds a Kubeflow Pipelines skill where an agent takes a prompt from a user(developer, data scientist, ML engineer), writes the Python code, tests the compilation, catches any errors, and feeds them back into itself until it successfully generates a valid pipeline file and then gets executed in a live backend cluster. 
Co-authored with @droctothorpe 

**Sponsors**

This request is sponsored by the following existing org members and maintainers:

- @chasecadet 
- @droctothorpe 

**Test Output** 


<img width="1567" height="307" alt="Screenshot 2026-08-20 121652" src="https://github.com/user-attachments/assets/cbcf18fa-a1d5-46a8-9f6a-8fe5c889840e" />