### PR TITLE
Add pratik-naik003 as Kubeflow org member

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -388,6 +388,7 @@ orgs:
         - pineking
         - pingsutw
         - ppadti
+        - pratik-naik003
         - pratyusharavi
         - priyank766
         - Priyanshu-u07


### PR DESCRIPTION
## Description

Adds `pratik-naik003` to the `orgs.kubeflow.members` list in `github-orgs/kubeflow/org.yaml`.


### Merged Contributions — `kubeflow/mcp-server`

- [fix: correct MCP_TRANSPORT default #124](https://github.com/kubeflow/mcp-server/pull/124) — Corrected the documented default transport from `http` to `stdio` to match the actual server configuration.
- [fix: remove unavailable agent command docs #125](https://github.com/kubeflow/mcp-server/pull/125) — Removed unsupported `kubeflow-mcp agent` documentation and outdated agent-specific OpenTelemetry information.
- [fix: correct OpenTelemetry installation command #127](https://github.com/kubeflow/mcp-server/pull/127) — Corrected the OpenTelemetry installation command to use the project's `uv` dependency group.
- [fix: clarify update training job confirmation #129](https://github.com/kubeflow/mcp-server/pull/129) — Clarified the confirmation behavior of `update_training_job` in the README.
- [fix: clarify log format default #131](https://github.com/kubeflow/mcp-server/pull/131) — Corrected documentation for the auto-detected `LOG_FORMAT` behavior.
- [fix: correct OpenTelemetry install warning #133](https://github.com/kubeflow/mcp-server/pull/133) — Fixed the OpenTelemetry missing-dependency warning and its installation guidance.
- [fix: preserve OTLP endpoint query parameters #140](https://github.com/kubeflow/mcp-server/pull/140) — Fixed OTLP endpoint normalization so existing query parameters are preserved correctly, with regression test coverage.
- [fix: handle non-mapping YAML config #142](https://github.com/kubeflow/mcp-server/pull/142) — Safely handled valid YAML configurations with non-mapping root values and added regression coverage.
- [fix: make CLI serve example copyable #144](https://github.com/kubeflow/mcp-server/pull/144) — Made the `kubeflow-mcp serve` README example safe to copy and paste in Bash.
- [docs: document KUBEFLOW_MCP_INSTRUCTION_TIER #146](https://github.com/kubeflow/mcp-server/pull/146) — Added documentation for the `KUBEFLOW_MCP_INSTRUCTION_TIER` environment variable and its supported options.
- [fix: prefer project-local configuration #151](https://github.com/kubeflow/mcp-server/pull/151) — Made project-local `.kubeflow-mcp.yaml` configuration take precedence over global configuration, with focused unit testing.
- [fix: validate discovery resource names #163](https://github.com/kubeflow/mcp-server/pull/163) — Added Kubernetes resource-name validation to Trainer discovery tools so invalid names return `VALIDATION_ERROR` before reaching the SDK.
- [fix: validate monitoring job names #165](https://github.com/kubeflow/mcp-server/pull/165) — Added training-job name validation across monitoring tools before Trainer/Kubernetes SDK calls.

### Open Contributions — `kubeflow/docs-agent`

- [fix: update API server paths in README #226](https://github.com/kubeflow/docs-agent/pull/226) — Updated API server paths to the `legacy/` directory to prevent `FileNotFoundError` for new users.
- [fix: inconsistent Milvus hostname default values #228](https://github.com/kubeflow/docs-agent/pull/228) — Unified inconsistent Milvus hostname defaults across README configuration tables.
- [fix: remove outdated Future Improvements section #230](https://github.com/kubeflow/docs-agent/pull/230) — Removed outdated embedding-model architectural guidance that conflicted with the current implementation.

### Open Contributions — `kubeflow/sdk`

- [fix: undefined variable in Local Development snippet #745](https://github.com/kubeflow/sdk/pull/745) — Fixed an undefined `train_fn` in the Local Development README example so it can be copied and executed without a `NameError`.

### Open Contributions — `kubeflow/website`

- [fix: add Makefile local setup commands #4454](https://github.com/kubeflow/website/pull/4454) — Added `make setup`, `make serve`, and `make build` commands and simplified the README local development instructions.


## Sponsors
@abhijeet-dhumal 
@jaiakash 



## Related Issue

Closes #960

## Testing

Validated the organization YAML locally:

```bash
cd github-orgs
py test_org_yaml.py