### PR TITLE
Add Sharkyii as Kubeflow org member

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -445,6 +445,7 @@ orgs:
         - sen-sam
         - seong7
         - shannonbradshaw
+        - Sharkyii
         - shawnzhu
         - shbijlan
         - shekharrajak


### PR DESCRIPTION
## Membership Request: @Sharkyii

This PR adds `Sharkyii` to the `org.kubeflow.members` list.

**Tracking Issue:** kubeflow/internal-acls#965

I am an active contributor to `kubeflow/docs-agent` and `kubeflow/pipelines`, where my work spans backend fixes, SDK features, frontend bugs, and reliability work on the docs-agent RAG ingestion pipeline.

### Key Contributions (`kubeflow/docs-agent`, `kubeflow/pipelines`)

- **fix(pipelines): add Milvus authentication to incremental ingestion** - [docs-agent#213](https://github.com/kubeflow/docs-agent/pull/213)
  Added `MILVUS_USER` / `MILVUS_PASSWORD` handling and wired the `milvus-auth` Kubernetes secret into the relevant pipeline tasks. Verified against an auth-enabled Milvus instance; lint, compilation, and tests passed.

- **fix(pipelines): stop shipping a CUDA image for CPU-only embedding inference** - [docs-agent#224](https://github.com/kubeflow/docs-agent/pull/224)
  Removed unnecessary CUDA/PyTorch dependencies from the pipeline image and moved incremental embedding to the shared in-cluster TEI service, reducing image bloat for CPU-only workloads.

- **fix(backend, frontend): skip the unused run count query on the runs list page** - [pipelines#13951](https://github.com/kubeflow/pipelines/pull/13951)
  Removed an unused run-count query from the KFP runs list page to avoid unnecessary backend work.

- **feat(sdk): add Pydantic `BaseModel` support for component I/O** - [pipelines#13995](https://github.com/kubeflow/pipelines/pull/13995)
  Added support for Pydantic `BaseModel` as a component input/output type in the KFP SDK.

### Sponsors

This request is sponsored by the following existing org members:

- @chasecadet
- @jeffspahr
- @tarekabouzeid 

### Test Output
<img width="1574" height="398" alt="image" src="https://github.com/user-attachments/assets/bd071653-45e5-4464-90a4-8c5e0fd873f4" />
