### PR TITLE
Add @richabanker as Member of Kubeflow org

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -415,6 +415,7 @@ orgs:
         - rebeccamcfadden
         - RedbackThomson
         - revit13
+        - richabanker
         - richardsliu
         - rickyxie0929
         - rimolive


### PR DESCRIPTION
**Membership Request: @richabanker**
This PR adds richabanker as a project member.

**Key Contributions**
- https://github.com/kubeflow/notebooks/pull/1241
- https://github.com/kubeflow/notebooks/pull/1312

Beyond her code contributions, Richa was instrumental in driving the API proposal, design discussion, and technical ratification for the Workspace Pod Metrics feature:
- https://github.com/kubeflow/notebooks/issues/1223

**Sponsors**
This request is supported and sponsored by the following existing members:
@andyatmiami