### PR TITLE
chore: add jeffspahr as a Kubeflow organization owner

### DIFF
--- a/github-orgs/kubeflow/org.yaml
+++ b/github-orgs/kubeflow/org.yaml
@@ -13,6 +13,7 @@ orgs:
         - googlebot
         - chasecadet
         - james-jwu
+        - jeffspahr
         - juliusvonkohout
         - krook
         - thesuperzapper
@@ -241,7 +242,6 @@ orgs:
         - jasonliu747
         - jbottum
         - Jeffwan
-        - jeffspahr
         - jenny-s51
         - JerT33
         - jessesuen

--- a/github-orgs/manifests/validate_config.py
+++ b/github-orgs/manifests/validate_config.py
@@ -30,7 +30,7 @@ class CheckConfig(object):
     # TODO(jlewi): We should load this in via config map
     # Check that each admin is in a whitelist set of admins.
     allowed_admins = ["andreyvelich", "caniszczyk", "chasecadet", "chensun", "franciscojavierarceo",
-                      "googlebot", "google-oss-robot", "james-jwu", "jbottum", "jlewi", "johnugeorge",
+                      "googlebot", "google-oss-robot", "james-jwu", "jbottum", "jeffspahr", "jlewi", "johnugeorge",
                       "juliusvonkohout", "k8s-ci-robot", "krook", "terrytangyuan", "thesuperzapper",
                       "thelinuxfoundation", "zijianjoy"]
 


### PR DESCRIPTION
## Summary

Propose adding `jeffspahr` (Jeff Spahr), a Kubeflow Pipelines repository administrator and Kubeflow security-team member, as a Kubeflow organization owner to support ongoing security-advisory coordination and organization-level repository policy administration.

- Move `jeffspahr` from the top-level `members` list to `admins`, avoiding duplicate role entries.
- Add `jeffspahr` to the organization validator's `allowed_admins` list.
- Preserve existing team memberships and all other access configuration.

This is an organization-owner promotion for review by the existing owners. It does not change branch protections or ruleset bypass lists; any such changes remain separate decisions.

## Validation

From `github-orgs`:

- `pytest test_org_yaml.py` — **1 passed**.
- `python manifests/validate_config.py check_config kubeflow/org.yaml` — **config is valid**.
- `git diff --check` — passed.
- Parsed configuration comparison — only the intended member-to-admin promotion; all other configuration and team memberships unchanged.
